### PR TITLE
Restructured models

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '26.0.2'
+    compileSdkVersion 28
+    buildToolsVersion '28.0.3'
     defaultConfig {
         applicationId "com.sdsmdg.harjot.vectormasterdemo"
         minSdkVersion 16
-        targetSdkVersion 25
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -21,7 +21,7 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.3.0'
-    compile project(":vectormaster")
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation project(":vectormaster")
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.3.2'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Nov 17 02:03:24 IST 2017
+#Tue Mar 26 22:16:32 CET 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip

--- a/vectormaster/build.gradle
+++ b/vectormaster/build.gradle
@@ -13,7 +13,7 @@ ext {
     siteUrl = 'https://github.com/harjot-oberai/VectorMaster/'
     gitUrl = 'https://github.com/harjot-oberai/VectorMaster/.git'
 
-    libraryVersion = '1.1.3'
+    libraryVersion = '1.2.0'
 
     developerId = 'harjot-oberai'
     developerName = 'Harjot Singh Oberai'

--- a/vectormaster/build.gradle
+++ b/vectormaster/build.gradle
@@ -25,12 +25,12 @@ ext {
 }
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '26.0.2'
+    compileSdkVersion 28
+    buildToolsVersion '28.0.3'
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 25
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
 
@@ -46,8 +46,7 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.3.0'
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
 }
 
 apply from: 'https://raw.githubusercontent.com/nuuneoi/JCenter/master/installv1.gradle'

--- a/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/ModelParser.java
+++ b/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/ModelParser.java
@@ -205,7 +205,7 @@ public class ModelParser {
             ParentModel topGroupModel = parentModelStack.pop();
             parentModelStack.peek().addChild(topGroupModel);
           } else if (name.equals("vector")) {
-            vectorModel.init();
+            //we are done with parsing
           }
           break;
         }

--- a/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/ModelParser.java
+++ b/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/ModelParser.java
@@ -1,0 +1,224 @@
+package com.sdsmdg.harjot.vectormaster;
+
+import android.content.res.Resources;
+import com.sdsmdg.harjot.vectormaster.models.ClipPathModel;
+import com.sdsmdg.harjot.vectormaster.models.GroupModel;
+import com.sdsmdg.harjot.vectormaster.models.ParentModel;
+import com.sdsmdg.harjot.vectormaster.models.PathModel;
+import com.sdsmdg.harjot.vectormaster.models.VectorModel;
+import com.sdsmdg.harjot.vectormaster.utilities.Utils;
+import org.xmlpull.v1.XmlPullParser;
+import org.xmlpull.v1.XmlPullParserException;
+
+import java.io.IOException;
+import java.util.Stack;
+
+public class ModelParser {
+
+  int getAttrPosition(XmlPullParser xpp, String attrName) {
+    for (int i = 0; i < xpp.getAttributeCount(); i++) {
+      if (xpp.getAttributeName(i).equals(attrName)) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  public VectorModel buildVectorModel(Resources resources, int resID) {
+
+    if (resID == -1) {
+      return null;
+    }
+
+    XmlPullParser xpp = resources.getXml(resID);
+
+    int tempPosition;
+    VectorModel vectorModel = new VectorModel();
+    PathModel pathModel = new PathModel();
+    GroupModel groupModel = new GroupModel();
+    ClipPathModel clipPathModel = new ClipPathModel();
+    Stack<ParentModel> parentModelStack = new Stack<>();
+    parentModelStack.push(vectorModel);
+
+    try {
+      int event = xpp.getEventType();
+      while (event != XmlPullParser.END_DOCUMENT) {
+        String name = xpp.getName();
+        switch (event) {
+        case XmlPullParser.START_TAG:
+          if (name.equals("vector")) {
+            tempPosition = getAttrPosition(xpp, "viewportWidth");
+            vectorModel.setViewportWidth((tempPosition != -1) ?
+                Float.parseFloat(xpp.getAttributeValue(tempPosition)) :
+                DefaultValues.VECTOR_VIEWPORT_WIDTH);
+
+            tempPosition = getAttrPosition(xpp, "viewportHeight");
+            vectorModel.setViewportHeight((tempPosition != -1) ?
+                Float.parseFloat(xpp.getAttributeValue(tempPosition)) :
+                DefaultValues.VECTOR_VIEWPORT_HEIGHT);
+
+            tempPosition = getAttrPosition(xpp, "alpha");
+            vectorModel.setAlpha((tempPosition != -1) ?
+                Float.parseFloat(xpp.getAttributeValue(tempPosition)) :
+                DefaultValues.VECTOR_ALPHA);
+
+            tempPosition = getAttrPosition(xpp, "name");
+            vectorModel.setName((tempPosition != -1) ? xpp.getAttributeValue(tempPosition) : null);
+
+            tempPosition = getAttrPosition(xpp, "width");
+            vectorModel.setWidth((tempPosition != -1) ?
+                Utils.getFloatFromDimensionString(xpp.getAttributeValue(tempPosition)) :
+                DefaultValues.VECTOR_WIDTH);
+
+            tempPosition = getAttrPosition(xpp, "height");
+            vectorModel.setHeight((tempPosition != -1) ?
+                Utils.getFloatFromDimensionString(xpp.getAttributeValue(tempPosition)) :
+                DefaultValues.VECTOR_HEIGHT);
+          } else if (name.equals("path")) {
+            pathModel = new PathModel();
+
+            tempPosition = getAttrPosition(xpp, "name");
+            pathModel.setName((tempPosition != -1) ? xpp.getAttributeValue(tempPosition) : null);
+
+            tempPosition = getAttrPosition(xpp, "fillAlpha");
+            pathModel.setFillAlpha((tempPosition != -1) ?
+                Float.parseFloat(xpp.getAttributeValue(tempPosition)) :
+                DefaultValues.PATH_FILL_ALPHA);
+
+            tempPosition = getAttrPosition(xpp, "fillColor");
+            pathModel.setFillColor((tempPosition != -1) ?
+                Utils.getColorFromString(xpp.getAttributeValue(tempPosition)) :
+                DefaultValues.PATH_FILL_COLOR);
+
+            tempPosition = getAttrPosition(xpp, "fillType");
+            pathModel.setFillType((tempPosition != -1) ?
+                Utils.getFillTypeFromString(xpp.getAttributeValue(tempPosition)) :
+                DefaultValues.PATH_FILL_TYPE);
+
+            tempPosition = getAttrPosition(xpp, "pathData");
+            pathModel.setPathData((tempPosition != -1) ? xpp.getAttributeValue(tempPosition) : null);
+
+            tempPosition = getAttrPosition(xpp, "strokeAlpha");
+            pathModel.setStrokeAlpha((tempPosition != -1) ?
+                Float.parseFloat(xpp.getAttributeValue(tempPosition)) :
+                DefaultValues.PATH_STROKE_ALPHA);
+
+            tempPosition = getAttrPosition(xpp, "strokeColor");
+            pathModel.setStrokeColor((tempPosition != -1) ?
+                Utils.getColorFromString(xpp.getAttributeValue(tempPosition)) :
+                DefaultValues.PATH_STROKE_COLOR);
+
+            tempPosition = getAttrPosition(xpp, "strokeLineCap");
+            pathModel.setStrokeLineCap((tempPosition != -1) ?
+                Utils.getLineCapFromString(xpp.getAttributeValue(tempPosition)) :
+                DefaultValues.PATH_STROKE_LINE_CAP);
+
+            tempPosition = getAttrPosition(xpp, "strokeLineJoin");
+            pathModel.setStrokeLineJoin((tempPosition != -1) ?
+                Utils.getLineJoinFromString(xpp.getAttributeValue(tempPosition)) :
+                DefaultValues.PATH_STROKE_LINE_JOIN);
+
+            tempPosition = getAttrPosition(xpp, "strokeMiterLimit");
+            pathModel.setStrokeMiterLimit((tempPosition != -1) ?
+                Float.parseFloat(xpp.getAttributeValue(tempPosition)) :
+                DefaultValues.PATH_STROKE_MITER_LIMIT);
+
+            tempPosition = getAttrPosition(xpp, "strokeWidth");
+            pathModel.setStrokeWidth((tempPosition != -1) ?
+                Float.parseFloat(xpp.getAttributeValue(tempPosition)) :
+                DefaultValues.PATH_STROKE_WIDTH);
+
+            tempPosition = getAttrPosition(xpp, "trimPathEnd");
+            pathModel.setTrimPathEnd((tempPosition != -1) ?
+                Float.parseFloat(xpp.getAttributeValue(tempPosition)) :
+                DefaultValues.PATH_TRIM_PATH_END);
+
+            tempPosition = getAttrPosition(xpp, "trimPathOffset");
+            pathModel.setTrimPathOffset((tempPosition != -1) ?
+                Float.parseFloat(xpp.getAttributeValue(tempPosition)) :
+                DefaultValues.PATH_TRIM_PATH_OFFSET);
+
+            tempPosition = getAttrPosition(xpp, "trimPathStart");
+            pathModel.setTrimPathStart((tempPosition != -1) ?
+                Float.parseFloat(xpp.getAttributeValue(tempPosition)) :
+                DefaultValues.PATH_TRIM_PATH_START);
+
+          } else if (name.equals("group")) {
+            groupModel = new GroupModel();
+
+            tempPosition = getAttrPosition(xpp, "name");
+            groupModel.setName((tempPosition != -1) ? xpp.getAttributeValue(tempPosition) : null);
+
+            tempPosition = getAttrPosition(xpp, "pivotX");
+            groupModel.setPivotX((tempPosition != -1) ?
+                Float.parseFloat(xpp.getAttributeValue(tempPosition)) :
+                DefaultValues.GROUP_PIVOT_X);
+
+            tempPosition = getAttrPosition(xpp, "pivotY");
+            groupModel.setPivotY((tempPosition != -1) ?
+                Float.parseFloat(xpp.getAttributeValue(tempPosition)) :
+                DefaultValues.GROUP_PIVOT_Y);
+
+            tempPosition = getAttrPosition(xpp, "rotation");
+            groupModel.setRotation((tempPosition != -1) ?
+                Float.parseFloat(xpp.getAttributeValue(tempPosition)) :
+                DefaultValues.GROUP_ROTATION);
+
+            tempPosition = getAttrPosition(xpp, "scaleX");
+            groupModel.setScaleX((tempPosition != -1) ?
+                Float.parseFloat(xpp.getAttributeValue(tempPosition)) :
+                DefaultValues.GROUP_SCALE_X);
+
+            tempPosition = getAttrPosition(xpp, "scaleY");
+            groupModel.setScaleY((tempPosition != -1) ?
+                Float.parseFloat(xpp.getAttributeValue(tempPosition)) :
+                DefaultValues.GROUP_SCALE_Y);
+
+            tempPosition = getAttrPosition(xpp, "translateX");
+            groupModel.setTranslateX((tempPosition != -1) ?
+                Float.parseFloat(xpp.getAttributeValue(tempPosition)) :
+                DefaultValues.GROUP_TRANSLATE_X);
+
+            tempPosition = getAttrPosition(xpp, "translateY");
+            groupModel.setTranslateY((tempPosition != -1) ?
+                Float.parseFloat(xpp.getAttributeValue(tempPosition)) :
+                DefaultValues.GROUP_TRANSLATE_Y);
+
+            parentModelStack.push(groupModel);
+          } else if (name.equals("clip-path")) {
+            clipPathModel = new ClipPathModel();
+
+            tempPosition = getAttrPosition(xpp, "name");
+            clipPathModel.setName((tempPosition != -1) ? xpp.getAttributeValue(tempPosition) : null);
+
+            tempPosition = getAttrPosition(xpp, "pathData");
+            clipPathModel.setPathData((tempPosition != -1) ? xpp.getAttributeValue(tempPosition) : null);
+          }
+          break;
+
+        case XmlPullParser.END_TAG:
+          if (name.equals("path")) {
+            pathModel.calculateStatic();
+            parentModelStack.peek().addChild(pathModel);
+            vectorModel.getFullpath().addPath(pathModel.getPath());
+          } else if (name.equals("clip-path")) {
+            parentModelStack.peek().addChild(clipPathModel);
+          } else if (name.equals("group")) {
+            ParentModel topGroupModel = parentModelStack.pop();
+            parentModelStack.peek().addChild(topGroupModel);
+          } else if (name.equals("vector")) {
+            vectorModel.calculateStatic();
+          }
+          break;
+        }
+        event = xpp.next();
+      }
+    } catch (XmlPullParserException | IOException e) {
+      e.printStackTrace();
+    }
+
+    return vectorModel;
+
+  }
+
+}

--- a/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/ModelParser.java
+++ b/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/ModelParser.java
@@ -198,16 +198,14 @@ public class ModelParser {
 
         case XmlPullParser.END_TAG:
           if (name.equals("path")) {
-            pathModel.calculateStatic();
             parentModelStack.peek().addChild(pathModel);
-            vectorModel.getFullpath().addPath(pathModel.getPath());
           } else if (name.equals("clip-path")) {
             parentModelStack.peek().addChild(clipPathModel);
           } else if (name.equals("group")) {
             ParentModel topGroupModel = parentModelStack.pop();
             parentModelStack.peek().addChild(topGroupModel);
           } else if (name.equals("vector")) {
-            vectorModel.calculateStatic();
+            vectorModel.init();
           }
           break;
         }

--- a/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/ModelParser.java
+++ b/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/ModelParser.java
@@ -24,7 +24,7 @@ public class ModelParser {
     return -1;
   }
 
-  public VectorModel buildVectorModel(Resources resources, int resID) {
+  public VectorModel buildVectorModel(Resources resources, int resID, boolean useLegacyParser) {
 
     if (resID == -1) {
       return null;
@@ -96,7 +96,7 @@ public class ModelParser {
                 DefaultValues.PATH_FILL_TYPE);
 
             tempPosition = getAttrPosition(xpp, "pathData");
-            pathModel.setPathData((tempPosition != -1) ? xpp.getAttributeValue(tempPosition) : null);
+            pathModel.setPathData((tempPosition != -1) ? xpp.getAttributeValue(tempPosition) : null, useLegacyParser);
 
             tempPosition = getAttrPosition(xpp, "strokeAlpha");
             pathModel.setStrokeAlpha((tempPosition != -1) ?
@@ -192,7 +192,7 @@ public class ModelParser {
             clipPathModel.setName((tempPosition != -1) ? xpp.getAttributeValue(tempPosition) : null);
 
             tempPosition = getAttrPosition(xpp, "pathData");
-            clipPathModel.setPathData((tempPosition != -1) ? xpp.getAttributeValue(tempPosition) : null);
+            clipPathModel.setPathData((tempPosition != -1) ? xpp.getAttributeValue(tempPosition) : null, useLegacyParser);
           }
           break;
 

--- a/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/VectorMasterDrawable.java
+++ b/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/VectorMasterDrawable.java
@@ -13,6 +13,7 @@ import android.graphics.drawable.Drawable;
 
 import com.sdsmdg.harjot.vectormaster.models.ClipPathModel;
 import com.sdsmdg.harjot.vectormaster.models.GroupModel;
+import com.sdsmdg.harjot.vectormaster.models.ParentModel;
 import com.sdsmdg.harjot.vectormaster.models.PathModel;
 import com.sdsmdg.harjot.vectormaster.models.VectorModel;
 import com.sdsmdg.harjot.vectormaster.utilities.Utils;
@@ -34,8 +35,6 @@ public class VectorMasterDrawable extends Drawable {
 
     private float offsetX = 0.0f, offsetY = 0.0f;
     private float scaleX = 1.0f, scaleY = 1.0f;
-
-    private XmlPullParser xpp;
 
     String TAG = "VECTOR_MASTER";
 
@@ -78,166 +77,11 @@ public class VectorMasterDrawable extends Drawable {
     }
 
     private void buildVectorModel() {
-
         if (resID == -1) {
             vectorModel = null;
             return;
         }
-
-        xpp = resources.getXml(resID);
-
-        int tempPosition;
-        PathModel pathModel = new PathModel();
-        vectorModel = new VectorModel();
-        GroupModel groupModel = new GroupModel();
-        ClipPathModel clipPathModel = new ClipPathModel();
-        Stack<GroupModel> groupModelStack = new Stack<>();
-
-        try {
-            int event = xpp.getEventType();
-            while (event != XmlPullParser.END_DOCUMENT) {
-                String name = xpp.getName();
-                switch (event) {
-                    case XmlPullParser.START_TAG:
-                        if (name.equals("vector")) {
-                            tempPosition = getAttrPosition(xpp, "viewportWidth");
-                            vectorModel.setViewportWidth((tempPosition != -1) ? Float.parseFloat(xpp.getAttributeValue(tempPosition)) : DefaultValues.VECTOR_VIEWPORT_WIDTH);
-
-                            tempPosition = getAttrPosition(xpp, "viewportHeight");
-                            vectorModel.setViewportHeight((tempPosition != -1) ? Float.parseFloat(xpp.getAttributeValue(tempPosition)) : DefaultValues.VECTOR_VIEWPORT_HEIGHT);
-
-                            tempPosition = getAttrPosition(xpp, "alpha");
-                            vectorModel.setAlpha((tempPosition != -1) ? Float.parseFloat(xpp.getAttributeValue(tempPosition)) : DefaultValues.VECTOR_ALPHA);
-
-                            tempPosition = getAttrPosition(xpp, "name");
-                            vectorModel.setName((tempPosition != -1) ? xpp.getAttributeValue(tempPosition) : null);
-
-                            tempPosition = getAttrPosition(xpp, "width");
-                            vectorModel.setWidth((tempPosition != -1) ? Utils.getFloatFromDimensionString(xpp.getAttributeValue(tempPosition)) : DefaultValues.VECTOR_WIDTH);
-
-                            tempPosition = getAttrPosition(xpp, "height");
-                            vectorModel.setHeight((tempPosition != -1) ? Utils.getFloatFromDimensionString(xpp.getAttributeValue(tempPosition)) : DefaultValues.VECTOR_HEIGHT);
-                        } else if (name.equals("path")) {
-                            pathModel = new PathModel();
-
-                            tempPosition = getAttrPosition(xpp, "name");
-                            pathModel.setName((tempPosition != -1) ? xpp.getAttributeValue(tempPosition) : null);
-
-                            tempPosition = getAttrPosition(xpp, "fillAlpha");
-                            pathModel.setFillAlpha((tempPosition != -1) ? Float.parseFloat(xpp.getAttributeValue(tempPosition)) : DefaultValues.PATH_FILL_ALPHA);
-
-                            tempPosition = getAttrPosition(xpp, "fillColor");
-                            pathModel.setFillColor((tempPosition != -1) ? Utils.getColorFromString(xpp.getAttributeValue(tempPosition)) : DefaultValues.PATH_FILL_COLOR);
-
-                            tempPosition = getAttrPosition(xpp, "fillType");
-                            pathModel.setFillType((tempPosition != -1) ? Utils.getFillTypeFromString(xpp.getAttributeValue(tempPosition)) : DefaultValues.PATH_FILL_TYPE);
-
-                            tempPosition = getAttrPosition(xpp, "pathData");
-                            pathModel.setPathData((tempPosition != -1) ? xpp.getAttributeValue(tempPosition) : null);
-
-                            tempPosition = getAttrPosition(xpp, "strokeAlpha");
-                            pathModel.setStrokeAlpha((tempPosition != -1) ? Float.parseFloat(xpp.getAttributeValue(tempPosition)) : DefaultValues.PATH_STROKE_ALPHA);
-
-                            tempPosition = getAttrPosition(xpp, "strokeColor");
-                            pathModel.setStrokeColor((tempPosition != -1) ? Utils.getColorFromString(xpp.getAttributeValue(tempPosition)) : DefaultValues.PATH_STROKE_COLOR);
-
-                            tempPosition = getAttrPosition(xpp, "strokeLineCap");
-                            pathModel.setStrokeLineCap((tempPosition != -1) ? Utils.getLineCapFromString(xpp.getAttributeValue(tempPosition)) : DefaultValues.PATH_STROKE_LINE_CAP);
-
-                            tempPosition = getAttrPosition(xpp, "strokeLineJoin");
-                            pathModel.setStrokeLineJoin((tempPosition != -1) ? Utils.getLineJoinFromString(xpp.getAttributeValue(tempPosition)) : DefaultValues.PATH_STROKE_LINE_JOIN);
-
-                            tempPosition = getAttrPosition(xpp, "strokeMiterLimit");
-                            pathModel.setStrokeMiterLimit((tempPosition != -1) ? Float.parseFloat(xpp.getAttributeValue(tempPosition)) : DefaultValues.PATH_STROKE_MITER_LIMIT);
-
-                            tempPosition = getAttrPosition(xpp, "strokeWidth");
-                            pathModel.setStrokeWidth((tempPosition != -1) ? Float.parseFloat(xpp.getAttributeValue(tempPosition)) : DefaultValues.PATH_STROKE_WIDTH);
-
-                            tempPosition = getAttrPosition(xpp, "trimPathEnd");
-                            pathModel.setTrimPathEnd((tempPosition != -1) ? Float.parseFloat(xpp.getAttributeValue(tempPosition)) : DefaultValues.PATH_TRIM_PATH_END);
-
-                            tempPosition = getAttrPosition(xpp, "trimPathOffset");
-                            pathModel.setTrimPathOffset((tempPosition != -1) ? Float.parseFloat(xpp.getAttributeValue(tempPosition)) : DefaultValues.PATH_TRIM_PATH_OFFSET);
-
-                            tempPosition = getAttrPosition(xpp, "trimPathStart");
-                            pathModel.setTrimPathStart((tempPosition != -1) ? Float.parseFloat(xpp.getAttributeValue(tempPosition)) : DefaultValues.PATH_TRIM_PATH_START);
-
-                            pathModel.buildPath(useLegacyParser);
-                        } else if (name.equals("group")) {
-                            groupModel = new GroupModel();
-
-                            tempPosition = getAttrPosition(xpp, "name");
-                            groupModel.setName((tempPosition != -1) ? xpp.getAttributeValue(tempPosition) : null);
-
-                            tempPosition = getAttrPosition(xpp, "pivotX");
-                            groupModel.setPivotX((tempPosition != -1) ? Float.parseFloat(xpp.getAttributeValue(tempPosition)) : DefaultValues.GROUP_PIVOT_X);
-
-                            tempPosition = getAttrPosition(xpp, "pivotY");
-                            groupModel.setPivotY((tempPosition != -1) ? Float.parseFloat(xpp.getAttributeValue(tempPosition)) : DefaultValues.GROUP_PIVOT_Y);
-
-                            tempPosition = getAttrPosition(xpp, "rotation");
-                            groupModel.setRotation((tempPosition != -1) ? Float.parseFloat(xpp.getAttributeValue(tempPosition)) : DefaultValues.GROUP_ROTATION);
-
-                            tempPosition = getAttrPosition(xpp, "scaleX");
-                            groupModel.setScaleX((tempPosition != -1) ? Float.parseFloat(xpp.getAttributeValue(tempPosition)) : DefaultValues.GROUP_SCALE_X);
-
-                            tempPosition = getAttrPosition(xpp, "scaleY");
-                            groupModel.setScaleY((tempPosition != -1) ? Float.parseFloat(xpp.getAttributeValue(tempPosition)) : DefaultValues.GROUP_SCALE_Y);
-
-                            tempPosition = getAttrPosition(xpp, "translateX");
-                            groupModel.setTranslateX((tempPosition != -1) ? Float.parseFloat(xpp.getAttributeValue(tempPosition)) : DefaultValues.GROUP_TRANSLATE_X);
-
-                            tempPosition = getAttrPosition(xpp, "translateY");
-                            groupModel.setTranslateY((tempPosition != -1) ? Float.parseFloat(xpp.getAttributeValue(tempPosition)) : DefaultValues.GROUP_TRANSLATE_Y);
-
-                            groupModelStack.push(groupModel);
-                        } else if (name.equals("clip-path")) {
-                            clipPathModel = new ClipPathModel();
-
-                            tempPosition = getAttrPosition(xpp, "name");
-                            clipPathModel.setName((tempPosition != -1) ? xpp.getAttributeValue(tempPosition) : null);
-
-                            tempPosition = getAttrPosition(xpp, "pathData");
-                            clipPathModel.setPathData((tempPosition != -1) ? xpp.getAttributeValue(tempPosition) : null);
-
-                            clipPathModel.buildPath(useLegacyParser);
-                        }
-                        break;
-
-                    case XmlPullParser.END_TAG:
-                        if (name.equals("path")) {
-                            if (groupModelStack.size() == 0) {
-                                vectorModel.addPathModel(pathModel);
-                            } else {
-                                groupModelStack.peek().addPathModel(pathModel);
-                            }
-                            vectorModel.getFullpath().addPath(pathModel.getPath());
-                        } else if (name.equals("clip-path")) {
-                            if (groupModelStack.size() == 0) {
-                                vectorModel.addClipPathModel(clipPathModel);
-                            } else {
-                                groupModelStack.peek().addClipPathModel(clipPathModel);
-                            }
-                        } else if (name.equals("group")) {
-                            GroupModel topGroupModel = groupModelStack.pop();
-                            if (groupModelStack.size() == 0) {
-                                topGroupModel.setParent(null);
-                                vectorModel.addGroupModel(topGroupModel);
-                            } else {
-                                topGroupModel.setParent(groupModelStack.peek());
-                                groupModelStack.peek().addGroupModel(topGroupModel);
-                            }
-                        } else if (name.equals("vector")) {
-                            vectorModel.buildTransformMatrices();
-                        }
-                        break;
-                }
-                event = xpp.next();
-            }
-        } catch (XmlPullParserException | IOException e) {
-            e.printStackTrace();
-        }
-
+        vectorModel = new ModelParser().buildVectorModel(resources, resID);
     }
 
     private int getAttrPosition(XmlPullParser xpp, String attrName) {
@@ -306,10 +150,10 @@ public class VectorMasterDrawable extends Drawable {
         if (left != 0 || top != 0) {
             tempSaveCount = canvas.save();
             canvas.translate(left, top);
-            vectorModel.drawPaths(canvas, offsetX, offsetY, scaleX, scaleY);
+            vectorModel.draw(canvas, offsetX, offsetY, scaleX, scaleY);
             canvas.restoreToCount(tempSaveCount);
         } else {
-            vectorModel.drawPaths(canvas, offsetX, offsetY, scaleX, scaleY);
+            vectorModel.draw(canvas, offsetX, offsetY, scaleX, scaleY);
         }
 
     }
@@ -354,12 +198,12 @@ public class VectorMasterDrawable extends Drawable {
     }
 
     private void scaleAllPaths() {
-        vectorModel.scaleAllPaths(scaleMatrix);
+        vectorModel.scalePaths(scaleMatrix);
     }
 
     private void scaleAllStrokes() {
         strokeRatio = Math.min(width / vectorModel.getWidth(), height / vectorModel.getHeight());
-        vectorModel.scaleAllStrokeWidth(strokeRatio);
+        vectorModel.scaleStrokeWidth(strokeRatio);
     }
 
     public Path getFullPath() {
@@ -370,47 +214,15 @@ public class VectorMasterDrawable extends Drawable {
     }
 
     public GroupModel getGroupModelByName(String name) {
-        GroupModel gModel;
-        for (GroupModel groupModel : vectorModel.getGroupModels()) {
-            if (Utils.isEqual(groupModel.getName(), name)) {
-                return groupModel;
-            } else {
-                gModel = groupModel.getGroupModelByName(name);
-                if (gModel != null)
-                    return gModel;
-            }
-        }
-        return null;
+       return vectorModel.getGroupModelByName(name);
     }
 
     public PathModel getPathModelByName(String name) {
-        PathModel pModel = null;
-        for (PathModel pathModel : vectorModel.getPathModels()) {
-            if (Utils.isEqual(pathModel.getName(), name)) {
-                return pathModel;
-            }
-        }
-        for (GroupModel groupModel : vectorModel.getGroupModels()) {
-            pModel = groupModel.getPathModelByName(name);
-            if (pModel != null && Utils.isEqual(pModel.getName(), name))
-                return pModel;
-        }
-        return pModel;
+        return vectorModel.getPathModelByName(name);
     }
 
     public ClipPathModel getClipPathModelByName(String name) {
-        ClipPathModel cModel = null;
-        for (ClipPathModel clipPathModel : vectorModel.getClipPathModels()) {
-            if (Utils.isEqual(clipPathModel.getName(), name)) {
-                return clipPathModel;
-            }
-        }
-        for (GroupModel groupModel : vectorModel.getGroupModels()) {
-            cModel = groupModel.getClipPathModelByName(name);
-            if (cModel != null && Utils.isEqual(cModel.getName(), name))
-                return cModel;
-        }
-        return cModel;
+        return vectorModel.getClipPathModelByName(name);
     }
 
     public void update() {

--- a/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/VectorMasterDrawable.java
+++ b/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/VectorMasterDrawable.java
@@ -77,7 +77,7 @@ public class VectorMasterDrawable extends Drawable {
             vectorModel = null;
             return;
         }
-        vectorModel = new ModelParser().buildVectorModel(resources, resID);
+        vectorModel = new ModelParser().buildVectorModel(resources, resID, useLegacyParser);
     }
 
     private int getAttrPosition(XmlPullParser xpp, String attrName) {

--- a/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/VectorMasterDrawable.java
+++ b/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/VectorMasterDrawable.java
@@ -13,16 +13,10 @@ import android.graphics.drawable.Drawable;
 
 import com.sdsmdg.harjot.vectormaster.models.ClipPathModel;
 import com.sdsmdg.harjot.vectormaster.models.GroupModel;
-import com.sdsmdg.harjot.vectormaster.models.ParentModel;
 import com.sdsmdg.harjot.vectormaster.models.PathModel;
 import com.sdsmdg.harjot.vectormaster.models.VectorModel;
 import com.sdsmdg.harjot.vectormaster.utilities.Utils;
-
 import org.xmlpull.v1.XmlPullParser;
-import org.xmlpull.v1.XmlPullParserException;
-
-import java.io.IOException;
-import java.util.Stack;
 
 public class VectorMasterDrawable extends Drawable {
 
@@ -126,8 +120,6 @@ public class VectorMasterDrawable extends Drawable {
             height = bounds.height();
 
             buildScaleMatrix();
-            scaleAllPaths();
-            scaleAllStrokes();
         }
     }
 
@@ -145,15 +137,20 @@ public class VectorMasterDrawable extends Drawable {
             setBounds(0, 0, temp1, temp2);
         }
 
+        strokeRatio = Math.min(width / vectorModel.getWidth(), height / vectorModel.getHeight());
+        Matrix translation = new Matrix(scaleMatrix);
+        translation.postTranslate(offsetX, offsetY);
+        translation.postScale(scaleX, scaleY);
+
         setAlpha(Utils.getAlphaFromFloat(vectorModel.getAlpha()));
 
         if (left != 0 || top != 0) {
             tempSaveCount = canvas.save();
             canvas.translate(left, top);
-            vectorModel.draw(canvas, offsetX, offsetY, scaleX, scaleY);
+            vectorModel.draw(canvas, translation, strokeRatio);
             canvas.restoreToCount(tempSaveCount);
         } else {
-            vectorModel.draw(canvas, offsetX, offsetY, scaleX, scaleY);
+            vectorModel.draw(canvas, translation, strokeRatio);
         }
 
     }
@@ -195,15 +192,6 @@ public class VectorMasterDrawable extends Drawable {
         scaleRatio = ratio;
 
         scaleMatrix.postScale(ratio, ratio, width / 2, height / 2);
-    }
-
-    private void scaleAllPaths() {
-        vectorModel.scalePaths(scaleMatrix);
-    }
-
-    private void scaleAllStrokes() {
-        strokeRatio = Math.min(width / vectorModel.getWidth(), height / vectorModel.getHeight());
-        vectorModel.scaleStrokeWidth(strokeRatio);
     }
 
     public Path getFullPath() {

--- a/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/VectorMasterView.java
+++ b/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/VectorMasterView.java
@@ -13,13 +13,6 @@ import com.sdsmdg.harjot.vectormaster.models.ClipPathModel;
 import com.sdsmdg.harjot.vectormaster.models.GroupModel;
 import com.sdsmdg.harjot.vectormaster.models.PathModel;
 import com.sdsmdg.harjot.vectormaster.models.VectorModel;
-import com.sdsmdg.harjot.vectormaster.utilities.Utils;
-
-import org.xmlpull.v1.XmlPullParser;
-import org.xmlpull.v1.XmlPullParserException;
-
-import java.io.IOException;
-import java.util.Stack;
 
 public class VectorMasterView extends View {
 
@@ -29,8 +22,6 @@ public class VectorMasterView extends View {
     Resources resources;
     int resID = -1;
     boolean useLegacyParser = true;
-
-    XmlPullParser xpp;
 
     String TAG = "VECTOR_MASTER";
 
@@ -83,169 +74,8 @@ public class VectorMasterView extends View {
             return;
         }
 
-        xpp = resources.getXml(resID);
+        vectorModel = new ModelParser().buildVectorModel(resources, resID);
 
-        int tempPosition;
-        PathModel pathModel = new PathModel();
-        vectorModel = new VectorModel();
-        GroupModel groupModel = new GroupModel();
-        ClipPathModel clipPathModel = new ClipPathModel();
-        Stack<GroupModel> groupModelStack = new Stack<>();
-
-        try {
-            int event = xpp.getEventType();
-            while (event != XmlPullParser.END_DOCUMENT) {
-                String name = xpp.getName();
-                switch (event) {
-                    case XmlPullParser.START_TAG:
-                        if (name.equals("vector")) {
-                            tempPosition = getAttrPosition(xpp, "viewportWidth");
-                            vectorModel.setViewportWidth((tempPosition != -1) ? Float.parseFloat(xpp.getAttributeValue(tempPosition)) : DefaultValues.VECTOR_VIEWPORT_WIDTH);
-
-                            tempPosition = getAttrPosition(xpp, "viewportHeight");
-                            vectorModel.setViewportHeight((tempPosition != -1) ? Float.parseFloat(xpp.getAttributeValue(tempPosition)) : DefaultValues.VECTOR_VIEWPORT_HEIGHT);
-
-                            tempPosition = getAttrPosition(xpp, "alpha");
-                            vectorModel.setAlpha((tempPosition != -1) ? Float.parseFloat(xpp.getAttributeValue(tempPosition)) : DefaultValues.VECTOR_ALPHA);
-
-                            tempPosition = getAttrPosition(xpp, "name");
-                            vectorModel.setName((tempPosition != -1) ? xpp.getAttributeValue(tempPosition) : null);
-
-                            tempPosition = getAttrPosition(xpp, "width");
-                            vectorModel.setWidth((tempPosition != -1) ? Utils.getFloatFromDimensionString(xpp.getAttributeValue(tempPosition)) : DefaultValues.VECTOR_WIDTH);
-
-                            tempPosition = getAttrPosition(xpp, "height");
-                            vectorModel.setHeight((tempPosition != -1) ? Utils.getFloatFromDimensionString(xpp.getAttributeValue(tempPosition)) : DefaultValues.VECTOR_HEIGHT);
-                        } else if (name.equals("path")) {
-                            pathModel = new PathModel();
-
-                            tempPosition = getAttrPosition(xpp, "name");
-                            pathModel.setName((tempPosition != -1) ? xpp.getAttributeValue(tempPosition) : null);
-
-                            tempPosition = getAttrPosition(xpp, "fillAlpha");
-                            pathModel.setFillAlpha((tempPosition != -1) ? Float.parseFloat(xpp.getAttributeValue(tempPosition)) : DefaultValues.PATH_FILL_ALPHA);
-
-                            tempPosition = getAttrPosition(xpp, "fillColor");
-                            pathModel.setFillColor((tempPosition != -1) ? Utils.getColorFromString(xpp.getAttributeValue(tempPosition)) : DefaultValues.PATH_FILL_COLOR);
-
-                            tempPosition = getAttrPosition(xpp, "fillType");
-                            pathModel.setFillType((tempPosition != -1) ? Utils.getFillTypeFromString(xpp.getAttributeValue(tempPosition)) : DefaultValues.PATH_FILL_TYPE);
-
-                            tempPosition = getAttrPosition(xpp, "pathData");
-                            pathModel.setPathData((tempPosition != -1) ? xpp.getAttributeValue(tempPosition) : null);
-
-                            tempPosition = getAttrPosition(xpp, "strokeAlpha");
-                            pathModel.setStrokeAlpha((tempPosition != -1) ? Float.parseFloat(xpp.getAttributeValue(tempPosition)) : DefaultValues.PATH_STROKE_ALPHA);
-
-                            tempPosition = getAttrPosition(xpp, "strokeColor");
-                            pathModel.setStrokeColor((tempPosition != -1) ? Utils.getColorFromString(xpp.getAttributeValue(tempPosition)) : DefaultValues.PATH_STROKE_COLOR);
-
-                            tempPosition = getAttrPosition(xpp, "strokeLineCap");
-                            pathModel.setStrokeLineCap((tempPosition != -1) ? Utils.getLineCapFromString(xpp.getAttributeValue(tempPosition)) : DefaultValues.PATH_STROKE_LINE_CAP);
-
-                            tempPosition = getAttrPosition(xpp, "strokeLineJoin");
-                            pathModel.setStrokeLineJoin((tempPosition != -1) ? Utils.getLineJoinFromString(xpp.getAttributeValue(tempPosition)) : DefaultValues.PATH_STROKE_LINE_JOIN);
-
-                            tempPosition = getAttrPosition(xpp, "strokeMiterLimit");
-                            pathModel.setStrokeMiterLimit((tempPosition != -1) ? Float.parseFloat(xpp.getAttributeValue(tempPosition)) : DefaultValues.PATH_STROKE_MITER_LIMIT);
-
-                            tempPosition = getAttrPosition(xpp, "strokeWidth");
-                            pathModel.setStrokeWidth((tempPosition != -1) ? Float.parseFloat(xpp.getAttributeValue(tempPosition)) : DefaultValues.PATH_STROKE_WIDTH);
-
-                            tempPosition = getAttrPosition(xpp, "trimPathEnd");
-                            pathModel.setTrimPathEnd((tempPosition != -1) ? Float.parseFloat(xpp.getAttributeValue(tempPosition)) : DefaultValues.PATH_TRIM_PATH_END);
-
-                            tempPosition = getAttrPosition(xpp, "trimPathOffset");
-                            pathModel.setTrimPathOffset((tempPosition != -1) ? Float.parseFloat(xpp.getAttributeValue(tempPosition)) : DefaultValues.PATH_TRIM_PATH_OFFSET);
-
-                            tempPosition = getAttrPosition(xpp, "trimPathStart");
-                            pathModel.setTrimPathStart((tempPosition != -1) ? Float.parseFloat(xpp.getAttributeValue(tempPosition)) : DefaultValues.PATH_TRIM_PATH_START);
-
-                            pathModel.buildPath(useLegacyParser);
-                        } else if (name.equals("group")) {
-                            groupModel = new GroupModel();
-
-                            tempPosition = getAttrPosition(xpp, "name");
-                            groupModel.setName((tempPosition != -1) ? xpp.getAttributeValue(tempPosition) : null);
-
-                            tempPosition = getAttrPosition(xpp, "pivotX");
-                            groupModel.setPivotX((tempPosition != -1) ? Float.parseFloat(xpp.getAttributeValue(tempPosition)) : DefaultValues.GROUP_PIVOT_X);
-
-                            tempPosition = getAttrPosition(xpp, "pivotY");
-                            groupModel.setPivotY((tempPosition != -1) ? Float.parseFloat(xpp.getAttributeValue(tempPosition)) : DefaultValues.GROUP_PIVOT_Y);
-
-                            tempPosition = getAttrPosition(xpp, "rotation");
-                            groupModel.setRotation((tempPosition != -1) ? Float.parseFloat(xpp.getAttributeValue(tempPosition)) : DefaultValues.GROUP_ROTATION);
-
-                            tempPosition = getAttrPosition(xpp, "scaleX");
-                            groupModel.setScaleX((tempPosition != -1) ? Float.parseFloat(xpp.getAttributeValue(tempPosition)) : DefaultValues.GROUP_SCALE_X);
-
-                            tempPosition = getAttrPosition(xpp, "scaleY");
-                            groupModel.setScaleY((tempPosition != -1) ? Float.parseFloat(xpp.getAttributeValue(tempPosition)) : DefaultValues.GROUP_SCALE_Y);
-
-                            tempPosition = getAttrPosition(xpp, "translateX");
-                            groupModel.setTranslateX((tempPosition != -1) ? Float.parseFloat(xpp.getAttributeValue(tempPosition)) : DefaultValues.GROUP_TRANSLATE_X);
-
-                            tempPosition = getAttrPosition(xpp, "translateY");
-                            groupModel.setTranslateY((tempPosition != -1) ? Float.parseFloat(xpp.getAttributeValue(tempPosition)) : DefaultValues.GROUP_TRANSLATE_Y);
-
-                            groupModelStack.push(groupModel);
-                        } else if (name.equals("clip-path")) {
-                            clipPathModel = new ClipPathModel();
-
-                            tempPosition = getAttrPosition(xpp, "name");
-                            clipPathModel.setName((tempPosition != -1) ? xpp.getAttributeValue(tempPosition) : null);
-
-                            tempPosition = getAttrPosition(xpp, "pathData");
-                            clipPathModel.setPathData((tempPosition != -1) ? xpp.getAttributeValue(tempPosition) : null);
-
-                            clipPathModel.buildPath(useLegacyParser);
-                        }
-                        break;
-
-                    case XmlPullParser.END_TAG:
-                        if (name.equals("path")) {
-                            if (groupModelStack.size() == 0) {
-                                vectorModel.addPathModel(pathModel);
-                            } else {
-                                groupModelStack.peek().addPathModel(pathModel);
-                            }
-                            vectorModel.getFullpath().addPath(pathModel.getPath());
-                        } else if (name.equals("clip-path")) {
-                            if (groupModelStack.size() == 0) {
-                                vectorModel.addClipPathModel(clipPathModel);
-                            } else {
-                                groupModelStack.peek().addClipPathModel(clipPathModel);
-                            }
-                        } else if (name.equals("group")) {
-                            GroupModel topGroupModel = groupModelStack.pop();
-                            if (groupModelStack.size() == 0) {
-                                topGroupModel.setParent(null);
-                                vectorModel.addGroupModel(topGroupModel);
-                            } else {
-                                topGroupModel.setParent(groupModelStack.peek());
-                                groupModelStack.peek().addGroupModel(topGroupModel);
-                            }
-                        } else if (name.equals("vector")) {
-                            vectorModel.buildTransformMatrices();
-                        }
-                        break;
-                }
-                event = xpp.next();
-            }
-        } catch (XmlPullParserException | IOException e) {
-            e.printStackTrace();
-        }
-
-    }
-
-    int getAttrPosition(XmlPullParser xpp, String attrName) {
-        for (int i = 0; i < xpp.getAttributeCount(); i++) {
-            if (xpp.getAttributeName(i).equals(attrName)) {
-                return i;
-            }
-        }
-        return -1;
     }
 
     public int getResID() {
@@ -282,7 +112,7 @@ public class VectorMasterView extends View {
 
         setAlpha(vectorModel.getAlpha());
 
-        vectorModel.drawPaths(canvas);
+        vectorModel.draw(canvas);
 
     }
 
@@ -302,12 +132,12 @@ public class VectorMasterView extends View {
     }
 
     void scaleAllPaths() {
-        vectorModel.scaleAllPaths(scaleMatrix);
+        vectorModel.scalePaths(scaleMatrix);
     }
 
     void scaleAllStrokes() {
         strokeRatio = Math.min(width / vectorModel.getWidth(), height / vectorModel.getHeight());
-        vectorModel.scaleAllStrokeWidth(strokeRatio);
+        vectorModel.scaleStrokeWidth(strokeRatio);
     }
 
     public Path getFullPath() {
@@ -318,47 +148,15 @@ public class VectorMasterView extends View {
     }
 
     public GroupModel getGroupModelByName(String name) {
-        GroupModel gModel;
-        for (GroupModel groupModel : vectorModel.getGroupModels()) {
-            if (Utils.isEqual(groupModel.getName(), name)) {
-                return groupModel;
-            } else {
-                gModel = groupModel.getGroupModelByName(name);
-                if (gModel != null)
-                    return gModel;
-            }
-        }
-        return null;
+        return vectorModel.getGroupModelByName(name);
     }
 
     public PathModel getPathModelByName(String name) {
-        PathModel pModel = null;
-        for (PathModel pathModel : vectorModel.getPathModels()) {
-            if (Utils.isEqual(pathModel.getName(), name)) {
-                return pathModel;
-            }
-        }
-        for (GroupModel groupModel : vectorModel.getGroupModels()) {
-            pModel = groupModel.getPathModelByName(name);
-            if (pModel != null && Utils.isEqual(pModel.getName(), name))
-                return pModel;
-        }
-        return pModel;
+        return vectorModel.getPathModelByName(name);
     }
 
     public ClipPathModel getClipPathModelByName(String name) {
-        ClipPathModel cModel = null;
-        for (ClipPathModel clipPathModel : vectorModel.getClipPathModels()) {
-            if (Utils.isEqual(clipPathModel.getName(), name)) {
-                return clipPathModel;
-            }
-        }
-        for (GroupModel groupModel : vectorModel.getGroupModels()) {
-            cModel = groupModel.getClipPathModelByName(name);
-            if (cModel != null && Utils.isEqual(cModel.getName(), name))
-                return cModel;
-        }
-        return cModel;
+        return vectorModel.getClipPathModelByName(name);
     }
 
     public void update() {

--- a/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/VectorMasterView.java
+++ b/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/VectorMasterView.java
@@ -25,7 +25,10 @@ public class VectorMasterView extends View {
 
     String TAG = "VECTOR_MASTER";
 
-    private Matrix scaleMatrix;
+    private Matrix scaleMatrix = new Matrix();
+    private boolean scaleMatrixChanged;
+    private Matrix newScaleMatrix = new Matrix(); //create a matrix object which is reused on every scaleMatrix creation
+
 
     int width = 0, height = 0;
 
@@ -109,19 +112,19 @@ public class VectorMasterView extends View {
         }
 
         strokeRatio = Math.min(width / vectorModel.getWidth(), height / vectorModel.getHeight());
-        Matrix translation = new Matrix(scaleMatrix);
 
         setAlpha(vectorModel.getAlpha());
 
-        vectorModel.draw(canvas, translation, scaleRatio);
+        vectorModel.calculate(scaleMatrix, scaleMatrixChanged, strokeRatio);
+        scaleMatrixChanged = false;
+        vectorModel.draw(canvas);
 
     }
 
     void buildScaleMatrix() {
 
-        scaleMatrix = new Matrix();
-
-        scaleMatrix.postTranslate(width / 2 - vectorModel.getViewportWidth() / 2, height / 2 - vectorModel.getViewportHeight() / 2);
+        newScaleMatrix.reset();
+        newScaleMatrix.postTranslate(width / 2 - vectorModel.getViewportWidth() / 2, height / 2 - vectorModel.getViewportHeight() / 2);
 
         float widthRatio = width / vectorModel.getViewportWidth();
         float heightRatio = height / vectorModel.getViewportHeight();
@@ -129,7 +132,10 @@ public class VectorMasterView extends View {
 
         scaleRatio = ratio;
 
-        scaleMatrix.postScale(ratio, ratio, width / 2, height / 2);
+        newScaleMatrix.postScale(ratio, ratio, width / 2, height / 2);
+
+        scaleMatrix.set(newScaleMatrix);
+        scaleMatrixChanged = true;
     }
 
     public Path getFullPath() {
@@ -164,6 +170,6 @@ public class VectorMasterView extends View {
     }
 
     public Matrix getScaleMatrix() {
-        return scaleMatrix;
+        return new Matrix(scaleMatrix);
     }
 }

--- a/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/VectorMasterView.java
+++ b/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/VectorMasterView.java
@@ -77,7 +77,7 @@ public class VectorMasterView extends View {
             return;
         }
 
-        vectorModel = new ModelParser().buildVectorModel(resources, resID);
+        vectorModel = new ModelParser().buildVectorModel(resources, resID, useLegacyParser);
 
     }
 

--- a/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/VectorMasterView.java
+++ b/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/VectorMasterView.java
@@ -94,8 +94,6 @@ public class VectorMasterView extends View {
             height = h;
 
             buildScaleMatrix();
-            scaleAllPaths();
-            scaleAllStrokes();
         }
     }
 
@@ -110,9 +108,12 @@ public class VectorMasterView extends View {
             return;
         }
 
+        strokeRatio = Math.min(width / vectorModel.getWidth(), height / vectorModel.getHeight());
+        Matrix translation = new Matrix(scaleMatrix);
+
         setAlpha(vectorModel.getAlpha());
 
-        vectorModel.draw(canvas);
+        vectorModel.draw(canvas, translation, scaleRatio);
 
     }
 
@@ -129,15 +130,6 @@ public class VectorMasterView extends View {
         scaleRatio = ratio;
 
         scaleMatrix.postScale(ratio, ratio, width / 2, height / 2);
-    }
-
-    void scaleAllPaths() {
-        vectorModel.scalePaths(scaleMatrix);
-    }
-
-    void scaleAllStrokes() {
-        strokeRatio = Math.min(width / vectorModel.getWidth(), height / vectorModel.getHeight());
-        vectorModel.scaleStrokeWidth(strokeRatio);
     }
 
     public Path getFullPath() {

--- a/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/models/ClipPathModel.java
+++ b/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/models/ClipPathModel.java
@@ -24,11 +24,6 @@ public class ClipPathModel extends Model {
     }
 
     @Override
-    public void init() {
-       preparePath(new Matrix());
-    }
-
-    @Override
     public void prepare(Canvas canvas, Matrix parentTransformation, float strokeRatio) {
         canvas.clipPath(preparePath(parentTransformation));
     }

--- a/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/models/ClipPathModel.java
+++ b/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/models/ClipPathModel.java
@@ -10,45 +10,47 @@ import android.graphics.PorterDuffXfermode;
 public class ClipPathModel extends Model {
     private String pathData;
 
-    private Path originalPath;
     private Path path;
+    private Path transformedPath;
+    private Matrix lastTransformation;
 
     private Paint clipPaint;
 
     public ClipPathModel() {
         path = new Path();
-
         clipPaint = new Paint();
         clipPaint.setAntiAlias(true);
         clipPaint.setXfermode(new PorterDuffXfermode(PorterDuff.Mode.CLEAR));
     }
 
     @Override
-    public void prepare(Canvas canvas, float offsetX, float offsetY, float scaleX, float scaleY) {
-        canvas.clipPath(getScaledAndOffsetPath(path, offsetX, offsetY, scaleX, scaleY));
+    public void init() {
+       preparePath(new Matrix());
     }
 
     @Override
-    public void draw(Canvas canvas, float offsetX, float offsetY, float scaleX, float scaleY) {
+    public void prepare(Canvas canvas, Matrix parentTransformation, float strokeRatio) {
+        canvas.clipPath(preparePath(parentTransformation));
+    }
+
+    @Override
+    public void draw(Canvas canvas, Matrix parentTransformation, float strokeRatio) {
         //clip path does no drawing
     }
 
-    @Override
-    public void calculateStatic() {
-        originalPath = com.sdsmdg.harjot.vectormaster.utilities.legacyparser.PathParser.createPathFromPathData(pathData);
-        path = new Path(originalPath);
+    private Path preparePath(Matrix transformation) {
+        //try caching as much as possible to do path calculation only if necessary
+        if (path == null) {
+            path = com.sdsmdg.harjot.vectormaster.utilities.legacyparser.PathParser.createPathFromPathData(pathData);
+            transformedPath = null;
+        }
+        if (transformedPath == null || lastTransformation == null || !lastTransformation.equals(transformation)) {
+            transformedPath = transform(path, transformation);
+            lastTransformation = transformation;
+        }
+        return transformedPath;
     }
 
-    @Override
-    public void scaleStrokeWidth(float ratio) {
-
-    }
-
-    @Override
-    public void scalePaths(Matrix originalScaleMatrix, Matrix concatTransformMatrix) {
-        path = new Path(originalPath);
-        path.transform(concatTransformMatrix);
-    }
 
     public Paint getClipPaint() {
         return clipPaint;
@@ -64,6 +66,7 @@ public class ClipPathModel extends Model {
 
     public void setPathData(String pathData) {
         this.pathData = pathData;
+        path = null;
     }
 
     public Path getPath() {

--- a/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/models/ClipPathModel.java
+++ b/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/models/ClipPathModel.java
@@ -1,17 +1,13 @@
 package com.sdsmdg.harjot.vectormaster.models;
 
-
+import android.graphics.Canvas;
 import android.graphics.Matrix;
 import android.graphics.Paint;
 import android.graphics.Path;
 import android.graphics.PorterDuff;
 import android.graphics.PorterDuffXfermode;
-import android.graphics.RectF;
 
-import com.sdsmdg.harjot.vectormaster.utilities.parser.PathParser;
-
-public class ClipPathModel {
-    private String name;
+public class ClipPathModel extends Model {
     private String pathData;
 
     private Path originalPath;
@@ -27,20 +23,31 @@ public class ClipPathModel {
         clipPaint.setXfermode(new PorterDuffXfermode(PorterDuff.Mode.CLEAR));
     }
 
-    public void buildPath(boolean useLegacyParser) {
-        if (useLegacyParser) {
-            originalPath = com.sdsmdg.harjot.vectormaster.utilities.legacyparser.PathParser.createPathFromPathData(pathData);
-        } else {
-            originalPath = PathParser.doPath(pathData);
-        }
+    @Override
+    public void prepare(Canvas canvas, float offsetX, float offsetY, float scaleX, float scaleY) {
+        canvas.clipPath(getScaledAndOffsetPath(path, offsetX, offsetY, scaleX, scaleY));
+    }
 
+    @Override
+    public void draw(Canvas canvas, float offsetX, float offsetY, float scaleX, float scaleY) {
+        //clip path does no drawing
+    }
+
+    @Override
+    public void calculateStatic() {
+        originalPath = com.sdsmdg.harjot.vectormaster.utilities.legacyparser.PathParser.createPathFromPathData(pathData);
         path = new Path(originalPath);
     }
 
-    public void transform(Matrix matrix) {
-        path = new Path(originalPath);
+    @Override
+    public void scaleStrokeWidth(float ratio) {
 
-        path.transform(matrix);
+    }
+
+    @Override
+    public void scalePaths(Matrix originalScaleMatrix, Matrix concatTransformMatrix) {
+        path = new Path(originalPath);
+        path.transform(concatTransformMatrix);
     }
 
     public Paint getClipPaint() {
@@ -49,14 +56,6 @@ public class ClipPathModel {
 
     public void setClipPaint(Paint clipPaint) {
         this.clipPaint = clipPaint;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
     }
 
     public String getPathData() {
@@ -75,19 +74,6 @@ public class ClipPathModel {
         this.path = path;
     }
 
-    public Path getScaledAndOffsetPath(float offsetX, float offsetY, float scaleX, float scaleY) {
-        Path newPath = new Path(path);
-        newPath.offset(offsetX, offsetY);
-        newPath.transform(getScaleMatrix(newPath, scaleX, scaleY));
-        return newPath;
-    }
 
-    public Matrix getScaleMatrix(Path srcPath, float scaleX, float scaleY) {
-        Matrix scaleMatrix = new Matrix();
-        RectF rectF = new RectF();
-        srcPath.computeBounds(rectF, true);
-        scaleMatrix.setScale(scaleX, scaleY, rectF.left, rectF.top);
-        return scaleMatrix;
-    }
 
 }

--- a/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/models/ClipPathModel.java
+++ b/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/models/ClipPathModel.java
@@ -6,6 +6,7 @@ import android.graphics.Paint;
 import android.graphics.Path;
 import android.graphics.PorterDuff;
 import android.graphics.PorterDuffXfermode;
+import com.sdsmdg.harjot.vectormaster.utilities.parser.PathParser;
 
 public class ClipPathModel extends Model {
   private String pathData;
@@ -62,8 +63,17 @@ public class ClipPathModel extends Model {
   }
 
   public void setPathData(String pathData) {
+    setPathData(pathData, true);
+  }
+
+  public void setPathData(String pathData, boolean useLegacyParser) {
     this.pathData = pathData;
-    Path path = com.sdsmdg.harjot.vectormaster.utilities.legacyparser.PathParser.createPathFromPathData(pathData);
+    Path path = null;
+    if (useLegacyParser) {
+      path = com.sdsmdg.harjot.vectormaster.utilities.legacyparser.PathParser.createPathFromPathData(pathData);
+    } else {
+      path = PathParser.doPath(pathData);
+    }
     setPath(path);
   }
 

--- a/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/models/GroupModel.java
+++ b/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/models/GroupModel.java
@@ -1,30 +1,15 @@
 package com.sdsmdg.harjot.vectormaster.models;
 
-
-import android.graphics.Canvas;
 import android.graphics.Matrix;
 
 import com.sdsmdg.harjot.vectormaster.DefaultValues;
-import com.sdsmdg.harjot.vectormaster.utilities.Utils;
 
-import java.util.ArrayList;
-
-public class GroupModel {
-    private String name;
+public class GroupModel extends ParentModel {
 
     private float rotation;
     private float pivotX, pivotY;
     private float scaleX, scaleY;
     private float translateX, translateY;
-
-    private Matrix scaleMatrix;
-    private Matrix originalTransformMatrix;
-    private Matrix finalTransformMatrix;
-    private GroupModel parent;
-
-    private ArrayList<GroupModel> groupModels;
-    private ArrayList<PathModel> pathModels;
-    private ArrayList<ClipPathModel> clipPathModels;
 
     public GroupModel() {
         rotation = DefaultValues.GROUP_ROTATION;
@@ -34,185 +19,15 @@ public class GroupModel {
         scaleY = DefaultValues.GROUP_SCALE_Y;
         translateX = DefaultValues.GROUP_TRANSLATE_X;
         translateY = DefaultValues.GROUP_TRANSLATE_Y;
-
-        groupModels = new ArrayList<>();
-        pathModels = new ArrayList<>();
-        clipPathModels = new ArrayList<>();
     }
 
-    public void drawPaths(Canvas canvas, float offsetX, float offsetY, float scaleX, float scaleY) {
-        for (ClipPathModel clipPathModel : clipPathModels) {
-            canvas.clipPath(clipPathModel.getScaledAndOffsetPath(offsetX, offsetY, scaleX, scaleY));
-        }
-        for (GroupModel groupModel : groupModels) {
-            groupModel.drawPaths(canvas, offsetX, offsetY, scaleX, scaleY);
-        }
-        for (PathModel pathModel : pathModels) {
-            if (pathModel.isFillAndStroke()) {
-                pathModel.makeFillPaint();
-                canvas.drawPath(pathModel.getScaledAndOffsetPath(offsetX, offsetY, scaleX, scaleY), pathModel.getPathPaint());
-                pathModel.makeStrokePaint();
-                canvas.drawPath(pathModel.getScaledAndOffsetPath(offsetX, offsetY, scaleX, scaleY), pathModel.getPathPaint());
-            } else {
-                canvas.drawPath(pathModel.getScaledAndOffsetPath(offsetX, offsetY, scaleX, scaleY), pathModel.getPathPaint());
-            }
-        }
-    }
-
-    public void drawPaths(Canvas canvas) {
-        for (ClipPathModel clipPathModel : clipPathModels) {
-            canvas.clipPath(clipPathModel.getPath());
-        }
-        for (GroupModel groupModel : groupModels) {
-            groupModel.drawPaths(canvas);
-        }
-        for (PathModel pathModel : pathModels) {
-            if (pathModel.isFillAndStroke()) {
-                pathModel.makeFillPaint();
-                canvas.drawPath(pathModel.getPath(), pathModel.getPathPaint());
-                pathModel.makeStrokePaint();
-                canvas.drawPath(pathModel.getPath(), pathModel.getPathPaint());
-            } else {
-                canvas.drawPath(pathModel.getPath(), pathModel.getPathPaint());
-            }
-        }
-    }
-
-    public void scaleAllPaths(Matrix scaleMatrix) {
-        this.scaleMatrix = scaleMatrix;
-        finalTransformMatrix = new Matrix(originalTransformMatrix);
-        finalTransformMatrix.postConcat(scaleMatrix);
-        for (GroupModel groupModel : groupModels) {
-            groupModel.scaleAllPaths(scaleMatrix);
-        }
-        for (PathModel pathModel : pathModels) {
-            pathModel.transform(finalTransformMatrix);
-        }
-        for (ClipPathModel clipPathModel : clipPathModels) {
-            clipPathModel.transform(finalTransformMatrix);
-        }
-    }
-
-    public void scaleAllStrokeWidth(float ratio) {
-        for (GroupModel groupModel : groupModels) {
-            groupModel.scaleAllStrokeWidth(ratio);
-        }
-        for (PathModel pathModel : pathModels) {
-            pathModel.setStrokeRatio(ratio);
-        }
-    }
-
-    public void buildTransformMatrix() {
-
-        originalTransformMatrix = new Matrix();
-
-        originalTransformMatrix.postScale(scaleX, scaleY, pivotX, pivotY);
-        originalTransformMatrix.postRotate(rotation, pivotX, pivotY);
-        originalTransformMatrix.postTranslate(translateX, translateY);
-
-        if (parent != null) {
-            originalTransformMatrix.postConcat(parent.getOriginalTransformMatrix());
-        }
-
-        for (GroupModel groupModel : groupModels) {
-            groupModel.buildTransformMatrix();
-        }
-    }
-
-    public void updateAndScalePaths() {
-        if (scaleMatrix != null) {
-            buildTransformMatrix();
-            scaleAllPaths(scaleMatrix);
-        }
-    }
-
-    public GroupModel getGroupModelByName(String name) {
-        GroupModel grpModel = null;
-        for (GroupModel groupModel : groupModels) {
-            if (Utils.isEqual(groupModel.getName(), name)) {
-                grpModel = groupModel;
-                return grpModel;
-            } else {
-                grpModel = groupModel.getGroupModelByName(name);
-                if (grpModel != null)
-                    return grpModel;
-            }
-        }
-        return grpModel;
-    }
-
-    public PathModel getPathModelByName(String name) {
-        PathModel pModel = null;
-        for (PathModel pathModel : pathModels) {
-            if (Utils.isEqual(pathModel.getName(), name)) {
-                return pathModel;
-            }
-        }
-        for (GroupModel groupModel : groupModels) {
-            pModel = groupModel.getPathModelByName(name);
-            if (pModel != null && Utils.isEqual(pModel.getName(), name))
-                return pModel;
-        }
-        return pModel;
-    }
-
-    public ClipPathModel getClipPathModelByName(String name) {
-        ClipPathModel cModel = null;
-        for (ClipPathModel clipPathModel : getClipPathModels()) {
-            if (Utils.isEqual(clipPathModel.getName(), name)) {
-                return clipPathModel;
-            }
-        }
-        for (GroupModel groupModel : getGroupModels()) {
-            cModel = groupModel.getClipPathModelByName(name);
-            if (cModel != null && Utils.isEqual(cModel.getName(), name))
-                return cModel;
-        }
-        return cModel;
-    }
-
-    public Matrix getOriginalTransformMatrix() {
-        return originalTransformMatrix;
-    }
-
-    public GroupModel getParent() {
-        return parent;
-    }
-
-    public void setParent(GroupModel parent) {
-        this.parent = parent;
-    }
-
-    public void addGroupModel(GroupModel groupModel) {
-        groupModels.add(groupModel);
-    }
-
-    public ArrayList<GroupModel> getGroupModels() {
-        return groupModels;
-    }
-
-    public void addPathModel(PathModel pathModel) {
-        pathModels.add(pathModel);
-    }
-
-    public ArrayList<PathModel> getPathModels() {
-        return pathModels;
-    }
-
-    public void addClipPathModel(ClipPathModel clipPathModel) {
-        clipPathModels.add(clipPathModel);
-    }
-
-    public ArrayList<ClipPathModel> getClipPathModels() {
-        return clipPathModels;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
+    @Override
+    protected Matrix createTransformMatrix() {
+        Matrix transformMatrix = new Matrix();
+        transformMatrix.postScale(scaleX, scaleY, pivotX, pivotY);
+        transformMatrix.postRotate(rotation, pivotX, pivotY);
+        transformMatrix.postTranslate(translateX, translateY);
+        return transformMatrix;
     }
 
     public float getRotation() {

--- a/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/models/GroupModel.java
+++ b/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/models/GroupModel.java
@@ -1,7 +1,6 @@
 package com.sdsmdg.harjot.vectormaster.models;
 
 import android.graphics.Matrix;
-
 import com.sdsmdg.harjot.vectormaster.DefaultValues;
 
 public class GroupModel extends ParentModel {

--- a/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/models/GroupModel.java
+++ b/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/models/GroupModel.java
@@ -1,93 +1,110 @@
 package com.sdsmdg.harjot.vectormaster.models;
 
+import android.graphics.Canvas;
 import android.graphics.Matrix;
 
 import com.sdsmdg.harjot.vectormaster.DefaultValues;
 
 public class GroupModel extends ParentModel {
 
-    private float rotation;
-    private float pivotX, pivotY;
-    private float scaleX, scaleY;
-    private float translateX, translateY;
+  private float rotation;
+  private float pivotX, pivotY;
+  private float scaleX, scaleY;
+  private float translateX, translateY;
+  private Matrix ownTransformation;
 
-    public GroupModel() {
-        rotation = DefaultValues.GROUP_ROTATION;
-        pivotX = DefaultValues.GROUP_PIVOT_X;
-        pivotY = DefaultValues.GROUP_PIVOT_Y;
-        scaleX = DefaultValues.GROUP_SCALE_X;
-        scaleY = DefaultValues.GROUP_SCALE_Y;
-        translateX = DefaultValues.GROUP_TRANSLATE_X;
-        translateY = DefaultValues.GROUP_TRANSLATE_Y;
-    }
+  public GroupModel() {
+    rotation = DefaultValues.GROUP_ROTATION;
+    pivotX = DefaultValues.GROUP_PIVOT_X;
+    pivotY = DefaultValues.GROUP_PIVOT_Y;
+    scaleX = DefaultValues.GROUP_SCALE_X;
+    scaleY = DefaultValues.GROUP_SCALE_Y;
+    translateX = DefaultValues.GROUP_TRANSLATE_X;
+    translateY = DefaultValues.GROUP_TRANSLATE_Y;
+  }
 
-    @Override
-    protected Matrix createTransformMatrix() {
-        Matrix transformMatrix = new Matrix();
-        transformMatrix.postScale(scaleX, scaleY, pivotX, pivotY);
-        transformMatrix.postRotate(rotation, pivotX, pivotY);
-        transformMatrix.postTranslate(translateX, translateY);
-        return transformMatrix;
-    }
+  @Override
+  public void draw(Canvas canvas, Matrix parentTransformation, float strokeRatio) {
 
-    public float getRotation() {
-        return rotation;
-    }
+    Matrix transformation = new Matrix(parentTransformation);
+    transformation.preConcat(ownTransformation);
 
-    public void setRotation(float rotation) {
-        this.rotation = rotation;
-        updateAndScalePaths();
-    }
+    super.draw(canvas, transformation, strokeRatio);
+  }
 
-    public float getPivotX() {
-        return pivotX;
-    }
+  protected void createOwnTransformation() {
+    Matrix transformation = new Matrix();
+    transformation.postScale(scaleX, scaleY, pivotX, pivotY);
+    transformation.postRotate(rotation, pivotX, pivotY);
+    transformation.postTranslate(translateX, translateY);
 
-    public void setPivotX(float pivotX) {
-        this.pivotX = pivotX;
-    }
+    ownTransformation = transformation;
+  }
 
-    public float getPivotY() {
-        return pivotY;
-    }
+  private void markAsDirty() {
+    createOwnTransformation();
+  }
 
-    public void setPivotY(float pivotY) {
-        this.pivotY = pivotY;
-    }
+  public float getRotation() {
+    return rotation;
+  }
 
-    public float getScaleX() {
-        return scaleX;
-    }
+  public void setRotation(float rotation) {
+    this.rotation = rotation;
+    markAsDirty();
+  }
 
-    public void setScaleX(float scaleX) {
-        this.scaleX = scaleX;
-        updateAndScalePaths();
-    }
+  public float getPivotX() {
+    return pivotX;
+  }
 
-    public float getScaleY() {
-        return scaleY;
-    }
+  public void setPivotX(float pivotX) {
+    this.pivotX = pivotX;
+    markAsDirty();
+  }
 
-    public void setScaleY(float scaleY) {
-        this.scaleY = scaleY;
-        updateAndScalePaths();
-    }
+  public float getPivotY() {
+    return pivotY;
+  }
 
-    public float getTranslateX() {
-        return translateX;
-    }
+  public void setPivotY(float pivotY) {
+    this.pivotY = pivotY;
+    markAsDirty();
+  }
 
-    public void setTranslateX(float translateX) {
-        this.translateX = translateX;
-        updateAndScalePaths();
-    }
+  public float getScaleX() {
+    return scaleX;
+  }
 
-    public float getTranslateY() {
-        return translateY;
-    }
+  public void setScaleX(float scaleX) {
+    this.scaleX = scaleX;
+    markAsDirty();
+  }
 
-    public void setTranslateY(float translateY) {
-        this.translateY = translateY;
-        updateAndScalePaths();
-    }
+  public float getScaleY() {
+    return scaleY;
+  }
+
+  public void setScaleY(float scaleY) {
+    this.scaleY = scaleY;
+    markAsDirty();
+  }
+
+  public float getTranslateX() {
+    return translateX;
+  }
+
+  public void setTranslateX(float translateX) {
+    this.translateX = translateX;
+    markAsDirty();
+  }
+
+  public float getTranslateY() {
+    return translateY;
+  }
+
+  public void setTranslateY(float translateY) {
+    this.translateY = translateY;
+    markAsDirty();
+  }
 }

--- a/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/models/GroupModel.java
+++ b/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/models/GroupModel.java
@@ -12,6 +12,9 @@ public class GroupModel extends ParentModel {
   private float scaleX, scaleY;
   private float translateX, translateY;
   private Matrix ownTransformation;
+  private boolean ownTransformationChanged = true;
+  private Matrix lastParentTransformation;
+  private Matrix lastTransformation;
 
   public GroupModel() {
     rotation = DefaultValues.GROUP_ROTATION;
@@ -26,10 +29,15 @@ public class GroupModel extends ParentModel {
   @Override
   public void draw(Canvas canvas, Matrix parentTransformation, float strokeRatio) {
 
-    Matrix transformation = new Matrix(parentTransformation);
-    transformation.preConcat(ownTransformation);
+    //try to keep transformed matrix the same instance as long as the values do not change
+    if (ownTransformationChanged || lastParentTransformation != parentTransformation) {
+      lastParentTransformation = parentTransformation;
+      lastTransformation = new Matrix(parentTransformation);
+      lastTransformation.preConcat(ownTransformation);
+      ownTransformationChanged = false;
+    }
 
-    super.draw(canvas, transformation, strokeRatio);
+    super.draw(canvas, lastTransformation, strokeRatio);
   }
 
   protected void createOwnTransformation() {
@@ -39,6 +47,7 @@ public class GroupModel extends ParentModel {
     transformation.postTranslate(translateX, translateY);
 
     ownTransformation = transformation;
+    ownTransformationChanged = true;
   }
 
   private void markAsDirty() {

--- a/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/models/Model.java
+++ b/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/models/Model.java
@@ -25,13 +25,16 @@ public abstract class Model {
     this.parent = parent;
   }
 
-  public abstract void prepare(Canvas canvas, Matrix parentTransformation, float strokeRatio);
-  public abstract void draw(Canvas canvas, Matrix parentTransformation, float strokeRatio);
+  public abstract void calculate(Matrix parentTransformation, Boolean transformationChanged, float strokeRatio);
+  public abstract void prepare(Canvas canvas);
+  public abstract void draw(Canvas canvas);
 
-  protected Path transform(Path path, Matrix transformation) {
-    Path resultPath = new Path(path);
-    resultPath.transform(transformation);
-    return resultPath;
+  /**
+   * adds the UNTRANSFORMED path to collectedPath
+   * @return
+   */
+  public void collectFullPath(Path collectedPath) {
+    //by default nothing to collect
   }
 
 }

--- a/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/models/Model.java
+++ b/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/models/Model.java
@@ -25,7 +25,6 @@ public abstract class Model {
     this.parent = parent;
   }
 
-  public abstract void init();
   public abstract void prepare(Canvas canvas, Matrix parentTransformation, float strokeRatio);
   public abstract void draw(Canvas canvas, Matrix parentTransformation, float strokeRatio);
 

--- a/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/models/Model.java
+++ b/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/models/Model.java
@@ -25,12 +25,19 @@ public abstract class Model {
     this.parent = parent;
   }
 
+  /**
+   * The rendering process always calls calculate(), perform(), draw() so that the models recalculate dynamically if needed.
+   * The methods should cache as much as possible and avoid allocation of new objects.
+   * @param parentTransformation
+   * @param transformationChanged
+   * @param strokeRatio
+   */
   public abstract void calculate(Matrix parentTransformation, Boolean transformationChanged, float strokeRatio);
   public abstract void prepare(Canvas canvas);
   public abstract void draw(Canvas canvas);
 
   /**
-   * adds the UNTRANSFORMED path to collectedPath
+   * adds the UNTRANSFORMED path (if the model has one) to collectedPath
    * @return
    */
   public void collectFullPath(Path collectedPath) {

--- a/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/models/Model.java
+++ b/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/models/Model.java
@@ -1,0 +1,69 @@
+package com.sdsmdg.harjot.vectormaster.models;
+
+import android.graphics.Canvas;
+import android.graphics.Matrix;
+import android.graphics.Path;
+import android.graphics.RectF;
+
+public abstract class Model {
+
+  private String name;
+  private ParentModel parent;
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public ParentModel getParent() {
+    return parent;
+  }
+
+  public void setParent(ParentModel parent) {
+    this.parent = parent;
+  }
+
+  public abstract void calculateStatic();
+
+  public abstract void scalePaths(Matrix originalScaleMatrix, Matrix concatTransformMatrix);
+
+  public abstract void scaleStrokeWidth(float ratio);
+
+  public abstract void prepare(Canvas canvas, float offsetX, float offsetY, float scaleX, float scaleY);
+
+  public abstract void draw(Canvas canvas, float offsetX, float offsetY, float scaleX, float scaleY);
+
+  public void draw(Canvas canvas) {
+    draw(canvas, 0.0f, 0.0f, 1.0f, 1.0f);
+  }
+
+  public void prepare(Canvas canvas) {
+    prepare(canvas, 0.0f, 0.0f, 1.0f, 1.0f);
+  }
+
+  public Path getScaledAndOffsetPath(Path srcPath, float offsetX, float offsetY, float scaleX, float scaleY) {
+    if (offsetX == 0 && offsetY == 0 && scaleX == 1 && scaleY == 1) {
+      return srcPath;
+    } else {
+      Path newPath = new Path(srcPath);
+      newPath.offset(offsetX, offsetY);
+      newPath.transform(getScaleMatrix(newPath, scaleX, scaleY));
+      return newPath;
+    }
+  }
+
+  public Matrix getScaleMatrix(Path srcPath, float scaleX, float scaleY) {
+    Matrix scaleMatrix = new Matrix();
+    RectF rectF = new RectF();
+    srcPath.computeBounds(rectF, true);
+    scaleMatrix.setScale(scaleX, scaleY, rectF.left, rectF.top);
+    return scaleMatrix;
+  }
+
+
+
+
+}

--- a/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/models/Model.java
+++ b/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/models/Model.java
@@ -3,7 +3,6 @@ package com.sdsmdg.harjot.vectormaster.models;
 import android.graphics.Canvas;
 import android.graphics.Matrix;
 import android.graphics.Path;
-import android.graphics.RectF;
 
 public abstract class Model {
 
@@ -26,44 +25,14 @@ public abstract class Model {
     this.parent = parent;
   }
 
-  public abstract void calculateStatic();
+  public abstract void init();
+  public abstract void prepare(Canvas canvas, Matrix parentTransformation, float strokeRatio);
+  public abstract void draw(Canvas canvas, Matrix parentTransformation, float strokeRatio);
 
-  public abstract void scalePaths(Matrix originalScaleMatrix, Matrix concatTransformMatrix);
-
-  public abstract void scaleStrokeWidth(float ratio);
-
-  public abstract void prepare(Canvas canvas, float offsetX, float offsetY, float scaleX, float scaleY);
-
-  public abstract void draw(Canvas canvas, float offsetX, float offsetY, float scaleX, float scaleY);
-
-  public void draw(Canvas canvas) {
-    draw(canvas, 0.0f, 0.0f, 1.0f, 1.0f);
+  protected Path transform(Path path, Matrix transformation) {
+    Path resultPath = new Path(path);
+    resultPath.transform(transformation);
+    return resultPath;
   }
-
-  public void prepare(Canvas canvas) {
-    prepare(canvas, 0.0f, 0.0f, 1.0f, 1.0f);
-  }
-
-  public Path getScaledAndOffsetPath(Path srcPath, float offsetX, float offsetY, float scaleX, float scaleY) {
-    if (offsetX == 0 && offsetY == 0 && scaleX == 1 && scaleY == 1) {
-      return srcPath;
-    } else {
-      Path newPath = new Path(srcPath);
-      newPath.offset(offsetX, offsetY);
-      newPath.transform(getScaleMatrix(newPath, scaleX, scaleY));
-      return newPath;
-    }
-  }
-
-  public Matrix getScaleMatrix(Path srcPath, float scaleX, float scaleY) {
-    Matrix scaleMatrix = new Matrix();
-    RectF rectF = new RectF();
-    srcPath.computeBounds(rectF, true);
-    scaleMatrix.setScale(scaleX, scaleY, rectF.left, rectF.top);
-    return scaleMatrix;
-  }
-
-
-
 
 }

--- a/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/models/Model.java
+++ b/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/models/Model.java
@@ -44,4 +44,20 @@ public abstract class Model {
     //by default nothing to collect
   }
 
+  protected Matrix initializeMatrix(Matrix matrix, Matrix initialValue) {
+    if (matrix == null) {
+      matrix = new Matrix(); //try to create new matrix objects as less as possible
+      if (initialValue != null) {
+        matrix.set(initialValue);
+      }
+    } else {
+      if (initialValue != null) {
+        matrix.set(initialValue);
+      } else {
+        matrix.reset();
+      }
+    }
+    return matrix;
+  }
+
 }

--- a/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/models/ParentModel.java
+++ b/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/models/ParentModel.java
@@ -10,13 +10,24 @@ public abstract class ParentModel extends Model {
 
   private ArrayList<Model> children = new ArrayList<>(0);
 
+  /**
+   * If you want to add a model consider using addChild() instead.
+   * Gets the list of children from this parent model.
+   * Make sure to add/remove/insert models only on the main-thread because the list of children is not thread save.
+   * Also make sure to call childModel.setParent(parent) when adding children to this list.
+   */
   public ArrayList<Model> getChildren() {
     return children;
   }
 
+  /**
+   * Adds a child model to this parent model. Also automatically sets the parent on the child model.
+   * Make sure to add new models on the main-thread because the list of children is not thread save.
+   * @param model
+   */
   public void addChild(Model model) {
-    getChildren().add(model);
     model.setParent(this);
+    getChildren().add(model);
   }
 
   @Override

--- a/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/models/ParentModel.java
+++ b/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/models/ParentModel.java
@@ -1,0 +1,122 @@
+package com.sdsmdg.harjot.vectormaster.models;
+
+import android.graphics.Canvas;
+import android.graphics.Matrix;
+
+import java.util.ArrayList;
+
+public abstract class ParentModel extends Model {
+
+  private ArrayList<Model> children = new ArrayList<>(0);
+  private Matrix scaleMatrix;
+  private Matrix transformMatrix;
+
+  public ArrayList<Model> getChildren() {
+    return children;
+  }
+
+  public void addChild(Model model) {
+    getChildren().add(model);
+    model.setParent(this);
+  }
+
+  public Matrix getTransformMatrix() {
+    return transformMatrix;
+  }
+
+  protected Matrix createTransformMatrix() {
+    return new Matrix();
+  }
+
+  @Override
+  public void calculateStatic() {
+    //create own matrix
+    transformMatrix = createTransformMatrix();
+    //add the one from the parrent if there is a parent
+    if (getParent() != null) {
+      transformMatrix.postConcat(getParent().getTransformMatrix());
+    }
+    //tell all children to do the calculation
+    for (Model model : getChildren()) {
+      model.calculateStatic();
+    }
+  }
+
+  @Override
+  public void scalePaths(Matrix originalScaleMatrix, Matrix concatTransformMatrix) {
+    this.scaleMatrix = originalScaleMatrix;
+    Matrix finalTransformMatrix = new Matrix(getTransformMatrix());
+    finalTransformMatrix.postConcat(scaleMatrix);
+    for (Model child : children) {
+      child.scalePaths(originalScaleMatrix, finalTransformMatrix);
+    }
+  }
+
+  public void scalePaths(Matrix originalScaleMatrix) {
+    scalePaths(originalScaleMatrix, null); //because we are a parentModel only the first Matrix matters the second one is not used.
+  }
+
+  public void updateAndScalePaths() {
+    if (scaleMatrix != null) {
+      calculateStatic();
+      scalePaths(scaleMatrix);
+    }
+  }
+
+  @Override
+  public void scaleStrokeWidth(float ratio) {
+    for (Model model : getChildren()) {
+      model.scaleStrokeWidth(ratio);
+    }
+  }
+
+  @Override
+  public void prepare(Canvas canvas, float offsetX, float offsetY, float scaleX, float scaleY) {
+    //parents by default do not prepare the canvas recursively
+  }
+
+  @Override
+  public void draw(Canvas canvas, float offsetX, float offsetY, float scaleX, float scaleY) {
+    //parents prepare just their own children before they draw
+    for (Model child : getChildren()) {
+      child.prepare(canvas, offsetX, offsetY, scaleX, scaleY);
+    }
+    for (Model child : getChildren()) {
+      child.draw(canvas, offsetX, offsetY, scaleX, scaleY);
+    }
+  }
+
+  public GroupModel getGroupModelByName(String name) {
+    return (GroupModel) getModelByTypeAndName(GroupModel.class, name);
+  }
+
+  public PathModel getPathModelByName(String name) {
+    return (PathModel) getModelByTypeAndName(PathModel.class, name);
+  }
+
+  public ClipPathModel getClipPathModelByName(String name) {
+    return (ClipPathModel) getModelByTypeAndName(ClipPathModel.class, name);
+  }
+
+  public Model getModelByTypeAndName(Class<? extends Model> clazz, String name) {
+    if (name == null) {
+      return null;
+    }
+    for (Model child : children) {
+      //check if the child is the searched model
+      if (name.equals(child.getName()) && clazz.isAssignableFrom(child.getClass())) {
+        return child;
+      }
+      //ask the child to check its children for the searched model
+      if (child instanceof ParentModel) {
+        Model subchild = ((ParentModel) child).getModelByTypeAndName(clazz, name);
+        if (subchild != null) {
+          return subchild;
+        }
+      }
+      //its not this child and not one of its children or children-children, so go on to the next child
+    }
+    return null; //searched element was not found withis this parent
+  }
+
+}

--- a/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/models/ParentModel.java
+++ b/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/models/ParentModel.java
@@ -8,8 +8,6 @@ import java.util.ArrayList;
 public abstract class ParentModel extends Model {
 
   private ArrayList<Model> children = new ArrayList<>(0);
-  private Matrix scaleMatrix;
-  private Matrix transformMatrix;
 
   public ArrayList<Model> getChildren() {
     return children;
@@ -20,69 +18,26 @@ public abstract class ParentModel extends Model {
     model.setParent(this);
   }
 
-  public Matrix getTransformMatrix() {
-    return transformMatrix;
-  }
-
-  protected Matrix createTransformMatrix() {
-    return new Matrix();
-  }
-
   @Override
-  public void calculateStatic() {
-    //create own matrix
-    transformMatrix = createTransformMatrix();
-    //add the one from the parrent if there is a parent
-    if (getParent() != null) {
-      transformMatrix.postConcat(getParent().getTransformMatrix());
-    }
-    //tell all children to do the calculation
-    for (Model model : getChildren()) {
-      model.calculateStatic();
+  public void init() {
+    for (Model child : getChildren()) {
+      child.init();
     }
   }
 
   @Override
-  public void scalePaths(Matrix originalScaleMatrix, Matrix concatTransformMatrix) {
-    this.scaleMatrix = originalScaleMatrix;
-    Matrix finalTransformMatrix = new Matrix(getTransformMatrix());
-    finalTransformMatrix.postConcat(scaleMatrix);
-    for (Model child : children) {
-      child.scalePaths(originalScaleMatrix, finalTransformMatrix);
-    }
-  }
-
-  public void scalePaths(Matrix originalScaleMatrix) {
-    scalePaths(originalScaleMatrix, null); //because we are a parentModel only the first Matrix matters the second one is not used.
-  }
-
-  public void updateAndScalePaths() {
-    if (scaleMatrix != null) {
-      calculateStatic();
-      scalePaths(scaleMatrix);
-    }
-  }
-
-  @Override
-  public void scaleStrokeWidth(float ratio) {
-    for (Model model : getChildren()) {
-      model.scaleStrokeWidth(ratio);
-    }
-  }
-
-  @Override
-  public void prepare(Canvas canvas, float offsetX, float offsetY, float scaleX, float scaleY) {
+  public void prepare(Canvas canvas, Matrix parentTransformation, float strokeRatio) {
     //parents by default do not prepare the canvas recursively
   }
 
   @Override
-  public void draw(Canvas canvas, float offsetX, float offsetY, float scaleX, float scaleY) {
+  public void draw(Canvas canvas, Matrix parentTransformation, float strokeRatio) {
     //parents prepare just their own children before they draw
     for (Model child : getChildren()) {
-      child.prepare(canvas, offsetX, offsetY, scaleX, scaleY);
+      child.prepare(canvas, parentTransformation, strokeRatio);
     }
     for (Model child : getChildren()) {
-      child.draw(canvas, offsetX, offsetY, scaleX, scaleY);
+      child.draw(canvas, parentTransformation, strokeRatio);
     }
   }
 

--- a/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/models/ParentModel.java
+++ b/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/models/ParentModel.java
@@ -2,6 +2,7 @@ package com.sdsmdg.harjot.vectormaster.models;
 
 import android.graphics.Canvas;
 import android.graphics.Matrix;
+import android.graphics.Path;
 
 import java.util.ArrayList;
 
@@ -19,18 +20,32 @@ public abstract class ParentModel extends Model {
   }
 
   @Override
-  public void prepare(Canvas canvas, Matrix parentTransformation, float strokeRatio) {
+  public void calculate(Matrix parentTransformation, Boolean transformationChanged, float strokeRatio) {
+    for (Model child : getChildren()) {
+      child.calculate(parentTransformation, transformationChanged, strokeRatio);
+    }
+  }
+
+  @Override
+  public void prepare(Canvas canvas) {
     //parents by default do not prepare the canvas recursively
   }
 
   @Override
-  public void draw(Canvas canvas, Matrix parentTransformation, float strokeRatio) {
+  public void draw(Canvas canvas) {
     //parents prepare just their own children before they draw
     for (Model child : getChildren()) {
-      child.prepare(canvas, parentTransformation, strokeRatio);
+      child.prepare(canvas);
     }
     for (Model child : getChildren()) {
-      child.draw(canvas, parentTransformation, strokeRatio);
+      child.draw(canvas);
+    }
+  }
+
+  @Override
+  public void collectFullPath(Path collectedPath) {
+    for (Model child : getChildren()) {
+      child.collectFullPath(collectedPath);
     }
   }
 

--- a/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/models/ParentModel.java
+++ b/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/models/ParentModel.java
@@ -19,13 +19,6 @@ public abstract class ParentModel extends Model {
   }
 
   @Override
-  public void init() {
-    for (Model child : getChildren()) {
-      child.init();
-    }
-  }
-
-  @Override
   public void prepare(Canvas canvas, Matrix parentTransformation, float strokeRatio) {
     //parents by default do not prepare the canvas recursively
   }

--- a/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/models/PathModel.java
+++ b/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/models/PathModel.java
@@ -132,7 +132,7 @@ public class PathModel extends Model {
       return;
     }
 
-    transformedPath.rewind();
+    //transformedPath.rewind();
     trimmedPath.transform(lastParentTransformation, transformedPath);
   }
 

--- a/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/models/PathModel.java
+++ b/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/models/PathModel.java
@@ -9,6 +9,7 @@ import android.graphics.PathMeasure;
 
 import com.sdsmdg.harjot.vectormaster.DefaultValues;
 import com.sdsmdg.harjot.vectormaster.utilities.Utils;
+import com.sdsmdg.harjot.vectormaster.utilities.parser.PathParser;
 
 public class PathModel extends Model {
 
@@ -217,8 +218,17 @@ public class PathModel extends Model {
   }
 
   public void setPathData(String pathData) {
+    setPathData(pathData, true);
+  }
+
+  public void setPathData(String pathData, boolean useLegacyParser) {
     this.pathData = pathData;
-    Path path = com.sdsmdg.harjot.vectormaster.utilities.legacyparser.PathParser.createPathFromPathData(pathData);
+    Path path = null;
+    if (useLegacyParser) {
+      path = com.sdsmdg.harjot.vectormaster.utilities.legacyparser.PathParser.createPathFromPathData(pathData);
+    } else {
+      path = PathParser.doPath(pathData);
+    }
     setPath(path);
   }
 

--- a/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/models/PathModel.java
+++ b/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/models/PathModel.java
@@ -1,314 +1,309 @@
 package com.sdsmdg.harjot.vectormaster.models;
 
+import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Matrix;
 import android.graphics.Paint;
 import android.graphics.Path;
 import android.graphics.PathMeasure;
-import android.graphics.RectF;
 
 import com.sdsmdg.harjot.vectormaster.DefaultValues;
-import com.sdsmdg.harjot.vectormaster.VectorMasterView;
 import com.sdsmdg.harjot.vectormaster.utilities.Utils;
-import com.sdsmdg.harjot.vectormaster.utilities.parser.PathParser;
 
-public class PathModel {
+public class PathModel extends Model {
 
-    private String name;
+  private float fillAlpha;
+  private int fillColor;
 
-    private float fillAlpha;
-    private int fillColor;
+  private Path.FillType fillType;
 
-    private Path.FillType fillType;
+  private String pathData;
 
-    private String pathData;
+  private float trimPathStart, trimPathEnd, trimPathOffset;
 
-    private float trimPathStart, trimPathEnd, trimPathOffset;
+  private float strokeAlpha;
+  private int strokeColor;
+  private Paint.Cap strokeLineCap;
+  private Paint.Join strokeLineJoin;
+  private float strokeMiterLimit;
+  private float strokeWidth;
 
-    private float strokeAlpha;
-    private int strokeColor;
-    private Paint.Cap strokeLineCap;
-    private Paint.Join strokeLineJoin;
-    private float strokeMiterLimit;
-    private float strokeWidth;
+  private float strokeRatio;
 
-    private float strokeRatio;
+  private boolean isFillAndStroke = false;
 
-    private boolean isFillAndStroke = false;
+  // Support for trim-paths is not available
 
-    // Support for trim-paths is not available
+  private Path originalPath;
+  private Path path;
+  private Path trimmedPath;
+  private Paint pathPaint;
 
-    private Path originalPath;
-    private Path path;
-    private Path trimmedPath;
-    private Paint pathPaint;
+  private Matrix scaleMatrix;
 
-    private Matrix scaleMatrix;
+  public PathModel() {
+    fillAlpha = DefaultValues.PATH_FILL_ALPHA;
+    fillColor = DefaultValues.PATH_FILL_COLOR;
+    fillType = DefaultValues.PATH_FILL_TYPE;
+    trimPathStart = DefaultValues.PATH_TRIM_PATH_START;
+    trimPathEnd = DefaultValues.PATH_TRIM_PATH_END;
+    trimPathOffset = DefaultValues.PATH_TRIM_PATH_OFFSET;
+    strokeAlpha = DefaultValues.PATH_STROKE_ALPHA;
+    strokeColor = DefaultValues.PATH_STROKE_COLOR;
+    strokeLineCap = DefaultValues.PATH_STROKE_LINE_CAP;
+    strokeLineJoin = DefaultValues.PATH_STROKE_LINE_JOIN;
+    strokeMiterLimit = DefaultValues.PATH_STROKE_MITER_LIMIT;
+    strokeWidth = DefaultValues.PATH_STROKE_WIDTH;
+    strokeRatio = DefaultValues.PATH_STROKE_RATIO;
 
-    public PathModel() {
-        fillAlpha = DefaultValues.PATH_FILL_ALPHA;
-        fillColor = DefaultValues.PATH_FILL_COLOR;
-        fillType = DefaultValues.PATH_FILL_TYPE;
-        trimPathStart = DefaultValues.PATH_TRIM_PATH_START;
-        trimPathEnd = DefaultValues.PATH_TRIM_PATH_END;
-        trimPathOffset = DefaultValues.PATH_TRIM_PATH_OFFSET;
-        strokeAlpha = DefaultValues.PATH_STROKE_ALPHA;
-        strokeColor = DefaultValues.PATH_STROKE_COLOR;
-        strokeLineCap = DefaultValues.PATH_STROKE_LINE_CAP;
-        strokeLineJoin = DefaultValues.PATH_STROKE_LINE_JOIN;
-        strokeMiterLimit = DefaultValues.PATH_STROKE_MITER_LIMIT;
-        strokeWidth = DefaultValues.PATH_STROKE_WIDTH;
-        strokeRatio = DefaultValues.PATH_STROKE_RATIO;
+    pathPaint = new Paint();
+    pathPaint.setAntiAlias(true);
+    updatePaint();
+  }
 
-        pathPaint = new Paint();
-        pathPaint.setAntiAlias(true);
-        updatePaint();
+  @Override
+  public void prepare(Canvas canvas, float offsetX, float offsetY, float scaleX, float scaleY) {
+    //path do not prepare
+  }
+
+  @Override
+  public void draw(Canvas canvas, float offsetX, float offsetY, float scaleX, float scaleY) {
+    Path pathToDraw = getScaledAndOffsetPath(path, offsetX, offsetY, scaleX, scaleY);
+    if (isFillAndStroke()) {
+      makeFillPaint();
+      canvas.drawPath(pathToDraw, getPathPaint());
+      makeStrokePaint();
+      canvas.drawPath(pathToDraw, getPathPaint());
+    } else {
+      canvas.drawPath(pathToDraw, getPathPaint());
+    }
+  }
+
+  public void updatePaint() {
+    pathPaint.setStrokeWidth(strokeWidth * strokeRatio);
+
+    if (fillColor != Color.TRANSPARENT && strokeColor != Color.TRANSPARENT) {
+      isFillAndStroke = true;
+    } else if (fillColor != Color.TRANSPARENT) {
+      pathPaint.setColor(fillColor);
+      pathPaint.setAlpha(Utils.getAlphaFromFloat(fillAlpha));
+      pathPaint.setStyle(Paint.Style.FILL);
+      isFillAndStroke = false;
+    } else if (strokeColor != Color.TRANSPARENT) {
+      pathPaint.setColor(strokeColor);
+      pathPaint.setAlpha(Utils.getAlphaFromFloat(strokeAlpha));
+      pathPaint.setStyle(Paint.Style.STROKE);
+      isFillAndStroke = false;
+    } else {
+      pathPaint.setColor(Color.TRANSPARENT);
     }
 
-    public void buildPath(boolean useLegacyParser) {
-        if (useLegacyParser) {
-            originalPath = com.sdsmdg.harjot.vectormaster.utilities.legacyparser.PathParser.createPathFromPathData(pathData);
-        } else {
-            originalPath = PathParser.doPath(pathData);
-        }
-        if (originalPath != null)
-            originalPath.setFillType(fillType);
+    pathPaint.setStrokeCap(strokeLineCap);
+    pathPaint.setStrokeJoin(strokeLineJoin);
+    pathPaint.setStrokeMiter(strokeMiterLimit);
+  }
 
+  public void makeStrokePaint() {
+    pathPaint.setColor(strokeColor);
+    pathPaint.setAlpha(Utils.getAlphaFromFloat(strokeAlpha));
+    pathPaint.setStyle(Paint.Style.STROKE);
+  }
+
+  public void makeFillPaint() {
+    pathPaint.setColor(fillColor);
+    pathPaint.setAlpha(Utils.getAlphaFromFloat(fillAlpha));
+    pathPaint.setStyle(Paint.Style.FILL);
+  }
+
+  @Override
+  public void scalePaths(Matrix originalScaleMatrix, Matrix concatTransformMatrix) {
+    scaleMatrix = concatTransformMatrix;
+    trimPath();
+  }
+
+  @Override
+  public void calculateStatic() {
+    originalPath = com.sdsmdg.harjot.vectormaster.utilities.legacyparser.PathParser.createPathFromPathData(pathData);
+    if (originalPath != null) {
+      originalPath.setFillType(fillType);
+    }
+    path = new Path(originalPath);
+  }
+
+  @Override
+  public void scaleStrokeWidth(float ratio) {
+    setStrokeRatio(ratio);
+  }
+
+  public void trimPath() {
+    if (scaleMatrix != null) {
+      if (trimPathStart == 0 && trimPathEnd == 1 && trimPathOffset == 0) {
         path = new Path(originalPath);
+        path.transform(scaleMatrix);
+      } else {
+        PathMeasure pathMeasure = new PathMeasure(originalPath, false);
+        float length = pathMeasure.getLength();
+        trimmedPath = new Path();
+        pathMeasure
+            .getSegment((trimPathStart + trimPathOffset) * length, (trimPathEnd + trimPathOffset) * length, trimmedPath,
+                true);
+        path = new Path(trimmedPath);
+        path.transform(scaleMatrix);
+      }
     }
+  }
 
-    public void updatePaint() {
-        pathPaint.setStrokeWidth(strokeWidth * strokeRatio);
+  public Path getTrimmedPath() {
+    return trimmedPath;
+  }
 
-        if (fillColor != Color.TRANSPARENT && strokeColor != Color.TRANSPARENT) {
-            isFillAndStroke = true;
-        } else if (fillColor != Color.TRANSPARENT) {
-            pathPaint.setColor(fillColor);
-            pathPaint.setAlpha(Utils.getAlphaFromFloat(fillAlpha));
-            pathPaint.setStyle(Paint.Style.FILL);
-            isFillAndStroke = false;
-        } else if (strokeColor != Color.TRANSPARENT) {
-            pathPaint.setColor(strokeColor);
-            pathPaint.setAlpha(Utils.getAlphaFromFloat(strokeAlpha));
-            pathPaint.setStyle(Paint.Style.STROKE);
-            isFillAndStroke = false;
-        } else {
-            pathPaint.setColor(Color.TRANSPARENT);
-        }
+  public void setTrimmedPath(Path trimmedPath) {
+    this.trimmedPath = trimmedPath;
+  }
 
-        pathPaint.setStrokeCap(strokeLineCap);
-        pathPaint.setStrokeJoin(strokeLineJoin);
-        pathPaint.setStrokeMiter(strokeMiterLimit);
-    }
+  public Path getPath() {
+    return path;
+  }
 
-    public void makeStrokePaint() {
-        pathPaint.setColor(strokeColor);
-        pathPaint.setAlpha(Utils.getAlphaFromFloat(strokeAlpha));
-        pathPaint.setStyle(Paint.Style.STROKE);
-    }
+  public void setPath(Path path) {
+    this.path = path;
+  }
 
-    public void makeFillPaint() {
-        pathPaint.setColor(fillColor);
-        pathPaint.setAlpha(Utils.getAlphaFromFloat(fillAlpha));
-        pathPaint.setStyle(Paint.Style.FILL);
-    }
+  public Paint getPathPaint() {
+    return pathPaint;
+  }
 
-    public void transform(Matrix matrix) {
-        scaleMatrix = matrix;
+  public void setPathPaint(Paint pathPaint) {
+    this.pathPaint = pathPaint;
+  }
 
-        trimPath();
-    }
+  public float getFillAlpha() {
+    return fillAlpha;
+  }
 
-    public void trimPath() {
-        if (scaleMatrix != null) {
-            if (trimPathStart == 0 && trimPathEnd == 1 && trimPathOffset == 0) {
-                path = new Path(originalPath);
-                path.transform(scaleMatrix);
-            } else {
-                PathMeasure pathMeasure = new PathMeasure(originalPath, false);
-                float length = pathMeasure.getLength();
-                trimmedPath = new Path();
-                pathMeasure.getSegment((trimPathStart + trimPathOffset) * length, (trimPathEnd + trimPathOffset) * length, trimmedPath, true);
-                path = new Path(trimmedPath);
-                path.transform(scaleMatrix);
-            }
-        }
-    }
+  public void setFillAlpha(float fillAlpha) {
+    this.fillAlpha = fillAlpha;
+    updatePaint();
+  }
 
-    public Path getTrimmedPath() {
-        return trimmedPath;
-    }
+  public int getFillColor() {
+    return fillColor;
+  }
 
-    public void setTrimmedPath(Path trimmedPath) {
-        this.trimmedPath = trimmedPath;
-    }
+  public void setFillColor(int fillColor) {
+    this.fillColor = fillColor;
+    updatePaint();
+  }
 
-    public Path getPath() {
-        return path;
-    }
+  public Path.FillType getFillType() {
+    return fillType;
+  }
 
-    public void setPath(Path path) {
-        this.path = path;
-    }
+  public void setFillType(Path.FillType fillType) {
+    this.fillType = fillType;
+    if (originalPath != null)
+      originalPath.setFillType(fillType);
+  }
 
-    public Path getScaledAndOffsetPath(float offsetX, float offsetY, float scaleX, float scaleY) {
-        Path newPath = new Path(path);
-        newPath.offset(offsetX, offsetY);
-        newPath.transform(getScaleMatrix(newPath, scaleX, scaleY));
-        return newPath;
-    }
+  public String getPathData() {
+    return pathData;
+  }
 
-    public Matrix getScaleMatrix(Path srcPath, float scaleX, float scaleY) {
-        Matrix scaleMatrix = new Matrix();
-        RectF rectF = new RectF();
-        srcPath.computeBounds(rectF, true);
-        scaleMatrix.setScale(scaleX, scaleY, rectF.left, rectF.top);
-        return scaleMatrix;
-    }
+  public void setPathData(String pathData) {
+    this.pathData = pathData;
+  }
 
-    public Paint getPathPaint() {
-        return pathPaint;
-    }
+  public float getTrimPathStart() {
+    return trimPathStart;
+  }
 
-    public void setPathPaint(Paint pathPaint) {
-        this.pathPaint = pathPaint;
-    }
+  public void setTrimPathStart(float trimPathStart) {
+    this.trimPathStart = trimPathStart;
+    trimPath();
+  }
 
-    public String getName() {
-        return name;
-    }
+  public float getTrimPathEnd() {
+    return trimPathEnd;
+  }
 
-    public void setName(String name) {
-        this.name = name;
-    }
+  public void setTrimPathEnd(float trimPathEnd) {
+    this.trimPathEnd = trimPathEnd;
+    trimPath();
+  }
 
-    public float getFillAlpha() {
-        return fillAlpha;
-    }
+  public float getTrimPathOffset() {
+    return trimPathOffset;
+  }
 
-    public void setFillAlpha(float fillAlpha) {
-        this.fillAlpha = fillAlpha;
-        updatePaint();
-    }
+  public void setTrimPathOffset(float trimPathOffset) {
+    this.trimPathOffset = trimPathOffset;
+    trimPath();
+  }
 
-    public int getFillColor() {
-        return fillColor;
-    }
+  public float getStrokeAlpha() {
+    return strokeAlpha;
+  }
 
-    public void setFillColor(int fillColor) {
-        this.fillColor = fillColor;
-        updatePaint();
-    }
+  public void setStrokeAlpha(float strokeAlpha) {
+    this.strokeAlpha = strokeAlpha;
+    updatePaint();
+  }
 
-    public Path.FillType getFillType() {
-        return fillType;
-    }
+  public int getStrokeColor() {
+    return strokeColor;
+  }
 
-    public void setFillType(Path.FillType fillType) {
-        this.fillType = fillType;
-        if (originalPath != null)
-            originalPath.setFillType(fillType);
-    }
+  public void setStrokeColor(int strokeColor) {
+    this.strokeColor = strokeColor;
+    updatePaint();
+  }
 
-    public String getPathData() {
-        return pathData;
-    }
+  public Paint.Cap getStrokeLineCap() {
+    return strokeLineCap;
+  }
 
-    public void setPathData(String pathData) {
-        this.pathData = pathData;
-    }
+  public void setStrokeLineCap(Paint.Cap strokeLineCap) {
+    this.strokeLineCap = strokeLineCap;
+    updatePaint();
+  }
 
-    public float getTrimPathStart() {
-        return trimPathStart;
-    }
+  public Paint.Join getStrokeLineJoin() {
+    return strokeLineJoin;
+  }
 
-    public void setTrimPathStart(float trimPathStart) {
-        this.trimPathStart = trimPathStart;
-        trimPath();
-    }
+  public void setStrokeLineJoin(Paint.Join strokeLineJoin) {
+    this.strokeLineJoin = strokeLineJoin;
+    updatePaint();
+  }
 
-    public float getTrimPathEnd() {
-        return trimPathEnd;
-    }
+  public float getStrokeMiterLimit() {
+    return strokeMiterLimit;
+  }
 
-    public void setTrimPathEnd(float trimPathEnd) {
-        this.trimPathEnd = trimPathEnd;
-        trimPath();
-    }
+  public void setStrokeMiterLimit(float strokeMiterLimit) {
+    this.strokeMiterLimit = strokeMiterLimit;
+    updatePaint();
+  }
 
-    public float getTrimPathOffset() {
-        return trimPathOffset;
-    }
+  public float getStrokeWidth() {
+    return strokeWidth;
+  }
 
-    public void setTrimPathOffset(float trimPathOffset) {
-        this.trimPathOffset = trimPathOffset;
-        trimPath();
-    }
+  public void setStrokeWidth(float strokeWidth) {
+    this.strokeWidth = strokeWidth;
+    updatePaint();
+  }
 
-    public float getStrokeAlpha() {
-        return strokeAlpha;
-    }
+  public float getStrokeRatio() {
+    return strokeRatio;
+  }
 
-    public void setStrokeAlpha(float strokeAlpha) {
-        this.strokeAlpha = strokeAlpha;
-        updatePaint();
-    }
+  public void setStrokeRatio(float strokeRatio) {
+    this.strokeRatio = strokeRatio;
+    updatePaint();
+  }
 
-    public int getStrokeColor() {
-        return strokeColor;
-    }
-
-    public void setStrokeColor(int strokeColor) {
-        this.strokeColor = strokeColor;
-        updatePaint();
-    }
-
-    public Paint.Cap getStrokeLineCap() {
-        return strokeLineCap;
-    }
-
-    public void setStrokeLineCap(Paint.Cap strokeLineCap) {
-        this.strokeLineCap = strokeLineCap;
-        updatePaint();
-    }
-
-    public Paint.Join getStrokeLineJoin() {
-        return strokeLineJoin;
-    }
-
-    public void setStrokeLineJoin(Paint.Join strokeLineJoin) {
-        this.strokeLineJoin = strokeLineJoin;
-        updatePaint();
-    }
-
-    public float getStrokeMiterLimit() {
-        return strokeMiterLimit;
-    }
-
-    public void setStrokeMiterLimit(float strokeMiterLimit) {
-        this.strokeMiterLimit = strokeMiterLimit;
-        updatePaint();
-    }
-
-    public float getStrokeWidth() {
-        return strokeWidth;
-    }
-
-    public void setStrokeWidth(float strokeWidth) {
-        this.strokeWidth = strokeWidth;
-        updatePaint();
-    }
-
-    public float getStrokeRatio() {
-        return strokeRatio;
-    }
-
-    public void setStrokeRatio(float strokeRatio) {
-        this.strokeRatio = strokeRatio;
-        updatePaint();
-    }
-
-    public boolean isFillAndStroke() {
-        return isFillAndStroke;
-    }
+  public boolean isFillAndStroke() {
+    return isFillAndStroke;
+  }
 }

--- a/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/models/PathModel.java
+++ b/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/models/PathModel.java
@@ -7,7 +7,6 @@ import android.graphics.Paint;
 import android.graphics.Path;
 import android.graphics.PathMeasure;
 
-import android.util.Log;
 import com.sdsmdg.harjot.vectormaster.DefaultValues;
 import com.sdsmdg.harjot.vectormaster.utilities.Utils;
 
@@ -31,12 +30,7 @@ public class PathModel extends Model {
   private float strokeRatio;
   private boolean strokeChanged;
 
-  private long averageDrawTime = 0L;
-  private int drawCount = 0;
-
   private boolean isFillAndStroke = false;
-
-  // Support for trim-paths is not available
 
   private Path path;
   private PathMeasure pathMeasure;
@@ -146,7 +140,6 @@ public class PathModel extends Model {
       return;
     }
 
-    // long startTime = System.nanoTime();
     if (trimPathStart != 0 || trimPathEnd != 1 || trimPathOffset != 0) {
       float trimStart = trimPathStart + trimPathOffset;
       float trimEnd = trimPathEnd + trimPathOffset;
@@ -160,20 +153,7 @@ public class PathModel extends Model {
     } else {
       trimmedPath.set(path);
     }
-/*
-    long endTime = System.nanoTime();
-    long drawTime = endTime - startTime;
-    if (averageDrawTime == 0) {
-      averageDrawTime = drawTime;
-    } else {
-      averageDrawTime = ((averageDrawTime + drawTime) / 2);
-    }
-    drawCount++;
-    if (drawCount == 500) {
-      drawCount = 0;
-      Log.i("TrimTimeTag", "Trim path took average " + averageDrawTime + " nanosecs");
-    }
-*/
+
     calculateTransformedPath();
   }
 

--- a/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/models/VectorModel.java
+++ b/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/models/VectorModel.java
@@ -10,113 +10,114 @@ import com.sdsmdg.harjot.vectormaster.enums.TintMode;
 
 public class VectorModel extends ParentModel {
 
-    private float width, height;
+  private float width, height;
 
-    private float alpha = 1.0f;
+  private float alpha = 1.0f;
 
-    private boolean autoMirrored = false;
+  private boolean autoMirrored = false;
 
-    private int tint = Color.TRANSPARENT;
-    private TintMode tintMode = TintMode.SCR_IN;
+  private int tint = Color.TRANSPARENT;
+  private TintMode tintMode = TintMode.SCR_IN;
 
-    private float viewportWidth, viewportHeight;
+  private float viewportWidth, viewportHeight;
 
-    private Path fullpath;
-    private long averageDrawTime = 0L;
-    private int drawCount = 0;
+  private Path fullpath;
+  private long averageDrawTime = 0L;
+  private int drawCount = 0;
 
-    public VectorModel() {
-        fullpath = new Path();
+  public VectorModel() {
+    fullpath = new Path();
+  }
+
+  /**
+   * returns the UNTRANSFORMED paths
+   * @return
+   */
+  public Path getFullpath() {
+    Path fullPath = new Path();
+    collectFullPath(fullPath);
+    return fullPath;
+  }
+
+  @Override
+  public void draw(Canvas canvas) {
+    long startTime = System.nanoTime();
+    super.draw(canvas);
+    long endTime = System.nanoTime();
+    long drawTime = endTime - startTime;
+    if (averageDrawTime == 0) {
+      averageDrawTime = drawTime;
+    } else {
+      averageDrawTime = ((averageDrawTime + drawTime) / 2);
     }
-
-    public Path getFullpath() {
-        //TODO: traverse the model to collect the currently translated pathes
-        throw new UnsupportedOperationException("Not implemented yet.");
+    drawCount++;
+    if (drawCount == 50) {
+      drawCount = 0;
+      Log.i("DrawTimeTag", "Draw took average " + averageDrawTime + " nanosecs");
     }
+  }
 
-    @Override
-    public void draw(Canvas canvas, Matrix parentTransformation, float strokeRatio) {
-        long startTime = System.nanoTime();
-        super.draw(canvas, parentTransformation, strokeRatio);
-        long endTime = System.nanoTime();
-        long drawTime = endTime - startTime;
-        if (averageDrawTime == 0) {
-            averageDrawTime = drawTime;
-        } else {
-            averageDrawTime = ((averageDrawTime + drawTime) / 2);
-        }
-        drawCount++;
-        if (drawCount == 50) {
-            drawCount = 0;
-            Log.i("DrawTimeTag", "Draw took average " + averageDrawTime + " nanosecs");
-        }
-    }
+  public float getWidth() {
+    return width;
+  }
 
-    public void setFullpath(Path fullpath) {
-        this.fullpath = fullpath;
-    }
+  public void setWidth(float width) {
+    this.width = width;
+  }
 
-    public float getWidth() {
-        return width;
-    }
+  public float getHeight() {
+    return height;
+  }
 
-    public void setWidth(float width) {
-        this.width = width;
-    }
+  public void setHeight(float height) {
+    this.height = height;
+  }
 
-    public float getHeight() {
-        return height;
-    }
+  public float getAlpha() {
+    return alpha;
+  }
 
-    public void setHeight(float height) {
-        this.height = height;
-    }
+  public void setAlpha(float alpha) {
+    this.alpha = alpha;
+  }
 
-    public float getAlpha() {
-        return alpha;
-    }
+  public boolean isAutoMirrored() {
+    return autoMirrored;
+  }
 
-    public void setAlpha(float alpha) {
-        this.alpha = alpha;
-    }
+  public void setAutoMirrored(boolean autoMirrored) {
+    this.autoMirrored = autoMirrored;
+  }
 
-    public boolean isAutoMirrored() {
-        return autoMirrored;
-    }
+  public int getTint() {
+    return tint;
+  }
 
-    public void setAutoMirrored(boolean autoMirrored) {
-        this.autoMirrored = autoMirrored;
-    }
+  public void setTint(int tint) {
+    this.tint = tint;
+  }
 
-    public int getTint() {
-        return tint;
-    }
+  public TintMode getTintMode() {
+    return tintMode;
+  }
 
-    public void setTint(int tint) {
-        this.tint = tint;
-    }
+  public void setTintMode(TintMode tintMode) {
+    this.tintMode = tintMode;
+  }
 
-    public TintMode getTintMode() {
-        return tintMode;
-    }
+  public float getViewportWidth() {
+    return viewportWidth;
+  }
 
-    public void setTintMode(TintMode tintMode) {
-        this.tintMode = tintMode;
-    }
+  public void setViewportWidth(float viewportWidth) {
+    this.viewportWidth = viewportWidth;
+  }
 
-    public float getViewportWidth() {
-        return viewportWidth;
-    }
+  public float getViewportHeight() {
+    return viewportHeight;
+  }
 
-    public void setViewportWidth(float viewportWidth) {
-        this.viewportWidth = viewportWidth;
-    }
-
-    public float getViewportHeight() {
-        return viewportHeight;
-    }
-
-    public void setViewportHeight(float viewportHeight) {
-        this.viewportHeight = viewportHeight;
-    }
+  public void setViewportHeight(float viewportHeight) {
+    this.viewportHeight = viewportHeight;
+  }
 }

--- a/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/models/VectorModel.java
+++ b/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/models/VectorModel.java
@@ -1,11 +1,8 @@
 package com.sdsmdg.harjot.vectormaster.models;
 
-import android.graphics.Canvas;
 import android.graphics.Color;
-import android.graphics.Matrix;
 import android.graphics.Path;
 
-import android.util.Log;
 import com.sdsmdg.harjot.vectormaster.enums.TintMode;
 
 public class VectorModel extends ParentModel {
@@ -21,12 +18,7 @@ public class VectorModel extends ParentModel {
 
   private float viewportWidth, viewportHeight;
 
-  private Path fullpath;
-  private long averageDrawTime = 0L;
-  private int drawCount = 0;
-
   public VectorModel() {
-    fullpath = new Path();
   }
 
   /**
@@ -37,24 +29,6 @@ public class VectorModel extends ParentModel {
     Path fullPath = new Path();
     collectFullPath(fullPath);
     return fullPath;
-  }
-
-  @Override
-  public void draw(Canvas canvas) {
-    long startTime = System.nanoTime();
-    super.draw(canvas);
-    long endTime = System.nanoTime();
-    long drawTime = endTime - startTime;
-    if (averageDrawTime == 0) {
-      averageDrawTime = drawTime;
-    } else {
-      averageDrawTime = ((averageDrawTime + drawTime) / 2);
-    }
-    drawCount++;
-    if (drawCount == 50) {
-      drawCount = 0;
-      Log.i("DrawTimeTag", "Draw took average " + averageDrawTime + " nanosecs");
-    }
   }
 
   public float getWidth() {

--- a/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/models/VectorModel.java
+++ b/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/models/VectorModel.java
@@ -1,8 +1,11 @@
 package com.sdsmdg.harjot.vectormaster.models;
 
+import android.graphics.Canvas;
 import android.graphics.Color;
+import android.graphics.Matrix;
 import android.graphics.Path;
 
+import android.util.Log;
 import com.sdsmdg.harjot.vectormaster.enums.TintMode;
 
 public class VectorModel extends ParentModel {
@@ -19,13 +22,34 @@ public class VectorModel extends ParentModel {
     private float viewportWidth, viewportHeight;
 
     private Path fullpath;
+    private long averageDrawTime = 0L;
+    private int drawCount = 0;
 
     public VectorModel() {
         fullpath = new Path();
     }
 
     public Path getFullpath() {
-        return fullpath;
+        //TODO: traverse the model to collect the currently translated pathes
+        throw new UnsupportedOperationException("Not implemented yet.");
+    }
+
+    @Override
+    public void draw(Canvas canvas, Matrix parentTransformation, float strokeRatio) {
+        long startTime = System.nanoTime();
+        super.draw(canvas, parentTransformation, strokeRatio);
+        long endTime = System.nanoTime();
+        long drawTime = endTime - startTime;
+        if (averageDrawTime == 0) {
+            averageDrawTime = drawTime;
+        } else {
+            averageDrawTime = ((averageDrawTime + drawTime) / 2);
+        }
+        drawCount++;
+        if (drawCount == 50) {
+            drawCount = 0;
+            Log.i("DrawTimeTag", "Draw took average " + averageDrawTime + " nanosecs");
+        }
     }
 
     public void setFullpath(Path fullpath) {

--- a/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/models/VectorModel.java
+++ b/vectormaster/src/main/java/com/sdsmdg/harjot/vectormaster/models/VectorModel.java
@@ -1,18 +1,11 @@
 package com.sdsmdg.harjot.vectormaster.models;
 
-import android.graphics.Canvas;
 import android.graphics.Color;
-import android.graphics.Matrix;
 import android.graphics.Path;
-import android.graphics.Region;
 
 import com.sdsmdg.harjot.vectormaster.enums.TintMode;
 
-import java.util.ArrayList;
-
-public class VectorModel {
-
-    private String name;
+public class VectorModel extends ParentModel {
 
     private float width, height;
 
@@ -25,109 +18,10 @@ public class VectorModel {
 
     private float viewportWidth, viewportHeight;
 
-    private ArrayList<GroupModel> groupModels;
-    private ArrayList<PathModel> pathModels;
-    private ArrayList<ClipPathModel> clipPathModels;
-
     private Path fullpath;
 
-    private Matrix scaleMatrix;
-
     public VectorModel() {
-        groupModels = new ArrayList<>();
-        pathModels = new ArrayList<>();
-        clipPathModels = new ArrayList<>();
         fullpath = new Path();
-    }
-
-    public void drawPaths(Canvas canvas, float offsetX, float offsetY, float scaleX, float scaleY) {
-        for (ClipPathModel clipPathModel : clipPathModels) {
-            canvas.clipPath(clipPathModel.getScaledAndOffsetPath(offsetX, offsetY, scaleX, scaleY));
-        }
-        for (GroupModel groupModel : groupModels) {
-            groupModel.drawPaths(canvas, offsetX, offsetY, scaleX, scaleY);
-        }
-        for (PathModel pathModel : pathModels) {
-            if (pathModel.isFillAndStroke()) {
-                pathModel.makeFillPaint();
-                canvas.drawPath(pathModel.getScaledAndOffsetPath(offsetX, offsetY, scaleX, scaleY), pathModel.getPathPaint());
-                pathModel.makeStrokePaint();
-                canvas.drawPath(pathModel.getScaledAndOffsetPath(offsetX, offsetY, scaleX, scaleY), pathModel.getPathPaint());
-            } else {
-                canvas.drawPath(pathModel.getScaledAndOffsetPath(offsetX, offsetY, scaleX, scaleY), pathModel.getPathPaint());
-            }
-        }
-    }
-
-    public void drawPaths(Canvas canvas) {
-        for (ClipPathModel clipPathModel : clipPathModels) {
-            canvas.clipPath(clipPathModel.getPath());
-        }
-        for (GroupModel groupModel : groupModels) {
-            groupModel.drawPaths(canvas);
-        }
-        for (PathModel pathModel : pathModels) {
-            if (pathModel.isFillAndStroke()) {
-                pathModel.makeFillPaint();
-                canvas.drawPath(pathModel.getPath(), pathModel.getPathPaint());
-                pathModel.makeStrokePaint();
-                canvas.drawPath(pathModel.getPath(), pathModel.getPathPaint());
-            } else {
-                canvas.drawPath(pathModel.getPath(), pathModel.getPathPaint());
-            }
-        }
-    }
-
-    public void scaleAllPaths(Matrix scaleMatrix) {
-        this.scaleMatrix = scaleMatrix;
-        for (GroupModel groupModel : groupModels) {
-            groupModel.scaleAllPaths(scaleMatrix);
-        }
-        for (PathModel pathModel : pathModels) {
-            pathModel.transform(scaleMatrix);
-        }
-        for (ClipPathModel clipPathModel : clipPathModels) {
-            clipPathModel.transform(scaleMatrix);
-        }
-    }
-
-    public void scaleAllStrokeWidth(float ratio) {
-        for (GroupModel groupModel : groupModels) {
-            groupModel.scaleAllStrokeWidth(ratio);
-        }
-        for (PathModel pathModel : pathModels) {
-            pathModel.setStrokeRatio(ratio);
-        }
-    }
-
-    public void buildTransformMatrices() {
-        for (GroupModel groupModel : groupModels) {
-            groupModel.buildTransformMatrix();
-        }
-    }
-
-    public void addGroupModel(GroupModel groupModel) {
-        groupModels.add(groupModel);
-    }
-
-    public ArrayList<GroupModel> getGroupModels() {
-        return groupModels;
-    }
-
-    public void addPathModel(PathModel pathModel) {
-        pathModels.add(pathModel);
-    }
-
-    public ArrayList<PathModel> getPathModels() {
-        return pathModels;
-    }
-
-    public void addClipPathModel(ClipPathModel clipPathModel) {
-        clipPathModels.add(clipPathModel);
-    }
-
-    public ArrayList<ClipPathModel> getClipPathModels() {
-        return clipPathModels;
     }
 
     public Path getFullpath() {
@@ -136,14 +30,6 @@ public class VectorModel {
 
     public void setFullpath(Path fullpath) {
         this.fullpath = fullpath;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
     }
 
     public float getWidth() {


### PR DESCRIPTION
Thanks for this awsome library! I used it in production code and it works very well. Still there were 2 issues with it:
- When a path and a group are sibling elements in the xml then the group was always drawn first, even if the path was first in xml. This changed drawing order, so that sometimes paths "disappeared".
- When VectorMasterDrawable was used and the rotation of a group was set programatically, then it happened that the rotation was not set. The problem was, that the rotation was tryed to be set before the Drawable first appeared. Therefore scaleMatrix was still null and the rotation could not be applied, because scaleMatrix only gets created when onBoundsChanged is called in the Drawable.

To solve these issues I needed to restructure the model classes and the way transformations are applied. I measured the drawing time before and after the code changes and it is still pretty much the same. 

It should also be possible to resolve issue #3 "Add functionality to dynamically add groups, paths etc. to the Vector" with this implementation, even adding/removing new models is not very comfortable. I did not explicitly tested adding models dynamically.